### PR TITLE
feat: configurable display mode for ask_user (overlay | inline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ High-quality video: [ask-user-demo.mp4](./media/ask-user-demo.mp4)
 - Optional freeform responses
 - User-toggleable extra context on structured selections
 - Context display support
-- Overlay mode — dialog floats over conversation, preserving context
+- Configurable display mode: `overlay` (modal, default) or `inline` (rendered directly in the flow)
 - Pi-TUI-aligned keybinding and editor behavior
 - Custom TUI rendering for tool calls and results
 - System prompt integration via `promptSnippet` and `promptGuidelines`
@@ -63,7 +63,8 @@ The registered tool name is:
 | `options` | `(string \| {title, description?})[]?` | `[]` | Multiple-choice options |
 | `allowMultiple` | `boolean?` | `false` | Enable multi-select mode |
 | `allowFreeform` | `boolean?` | `true` | Add a "Type something" freeform option |
-| `allowComment` | `boolean?` | `false` | Expose a user-toggleable extra-context option in the overlay (`ctrl+g` or the toggle row) and collect an optional comment in fallback dialogs |
+| `allowComment` | `boolean?` | `false` | Expose a user-toggleable extra-context option in the custom UI (`ctrl+g` or the toggle row) and collect an optional comment in fallback dialogs |
+| `displayMode` | `"overlay" \| "inline"?` | env var or `"overlay"` | Controls custom UI rendering: `overlay` shows the centered modal (current behavior), `inline` renders without overlay framing |
 | `timeout` | `number?` | — | Auto-dismiss after N ms and return `null` if the prompt times out |
 
 ## Example usage shape
@@ -78,9 +79,28 @@ The registered tool name is:
   ],
   "allowMultiple": false,
   "allowFreeform": true,
-  "allowComment": true
+  "allowComment": true,
+  "displayMode": "inline"
 }
 ```
+
+`displayMode: "inline"` uses the same interaction logic but skips overlay mode when calling `ctx.ui.custom(...)`. RPC/headless fallback behavior is unchanged.
+
+## Personal display mode preference
+
+Set the `PI_ASK_USER_DISPLAY_MODE` environment variable to configure your preferred default globally. Add it to your shell profile (`~/.zshrc`, `~/.bash_profile`, etc.):
+
+```bash
+export PI_ASK_USER_DISPLAY_MODE=inline
+```
+
+Effective behavior order:
+
+1. Per-call `displayMode` parameter (if provided)
+2. `PI_ASK_USER_DISPLAY_MODE` environment variable (if set to `"overlay"` or `"inline"`)
+3. Fallback default: `"overlay"`
+
+Unrecognised values are silently ignored and fall back to `"overlay"`.
 
 ## Result details
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { beforeAll, describe, expect, mock, onTestFinished, test } from "bun:test";
 
 let editorInputs: string[] = [];
 let editorText = "";
@@ -113,6 +113,7 @@ beforeAll(() => {
          Optional: (value: unknown) => value,
          Array: (value: unknown) => value,
          Union: (value: unknown) => value,
+         Literal: (value: unknown) => value,
          Boolean: (value?: unknown) => value,
          Number: (value?: unknown) => value,
       },
@@ -123,6 +124,18 @@ type RegisteredTool = {
    execute: (...args: any[]) => Promise<any>;
    renderResult: (result: any, options: any, theme: any) => any;
 };
+
+function stubEnv(key: string, value: string): void {
+   const original = process.env[key];
+   process.env[key] = value;
+   onTestFinished(() => {
+      if (original === undefined) {
+         delete process.env[key];
+      } else {
+         process.env[key] = original;
+      }
+   });
+}
 
 async function setupTool(): Promise<RegisteredTool> {
    const { default: askUserExtension } = await import("./index");
@@ -156,7 +169,7 @@ function createTheme() {
 }
 
 describe("ask_user", () => {
-   test("does not hide the overlay on narrow terminals", async () => {
+   test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;
 
@@ -181,6 +194,149 @@ describe("ask_user", () => {
 
       expect(capturedOptions.overlay).toBe(true);
       expect(capturedOptions.overlayOptions.visible).toBeUndefined();
+   });
+
+   test("uses non-overlay custom UI when displayMode is inline", async () => {
+      const tool = await setupTool();
+      let capturedOptions: any;
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+            displayMode: "inline",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (_factory: any, options: any) => {
+                  capturedOptions = options;
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(capturedOptions).toBeUndefined();
+      expect(result.details.cancelled).toBe(true);
+   });
+
+   test("inline mode still respects timeout cancellation", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+            displayMode: "inline",
+            timeout: 5,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) =>
+                  await new Promise((resolve) => {
+                     factory(
+                        { requestRender() { }, terminal: { rows: 24 } },
+                        createTheme(),
+                        createKeybindings(),
+                        resolve,
+                     );
+                  }),
+            },
+         },
+      );
+
+      expect(result.details.cancelled).toBe(true);
+      expect(result.details.response).toBeNull();
+   });
+
+   test("uses PI_ASK_USER_DISPLAY_MODE env var when call-level displayMode is omitted", async () => {
+      stubEnv("PI_ASK_USER_DISPLAY_MODE", "inline");
+      const tool = await setupTool();
+      let capturedOptions: any;
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (_factory: any, options: any) => {
+                  capturedOptions = options;
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(capturedOptions).toBeUndefined();
+   });
+
+   test("call-level displayMode overrides PI_ASK_USER_DISPLAY_MODE env var", async () => {
+      stubEnv("PI_ASK_USER_DISPLAY_MODE", "inline");
+      const tool = await setupTool();
+      let capturedOptions: any;
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+            displayMode: "overlay",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (_factory: any, options: any) => {
+                  capturedOptions = options;
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(capturedOptions.overlay).toBe(true);
+   });
+
+   test("ignores unrecognised PI_ASK_USER_DISPLAY_MODE value and falls back to overlay", async () => {
+      stubEnv("PI_ASK_USER_DISPLAY_MODE", "fullscreen");
+      const tool = await setupTool();
+      let capturedOptions: any;
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (_factory: any, options: any) => {
+                  capturedOptions = options;
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(capturedOptions.overlay).toBe(true);
    });
 
    test("renders partial updates as waiting state instead of a successful empty answer", async () => {

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,8 @@ const ASK_USER_VERSION: string = (_require("./package.json") as { version: strin
 
 type AskOptionInput = QuestionOption | string;
 
+type AskDisplayMode = "overlay" | "inline";
+
 interface AskParams {
    question: string;
    context?: string;
@@ -42,6 +44,7 @@ interface AskParams {
    allowMultiple?: boolean;
    allowFreeform?: boolean;
    allowComment?: boolean;
+   displayMode?: AskDisplayMode;
    timeout?: number;
 }
 
@@ -238,6 +241,23 @@ const SINGLE_SELECT_SPLIT_PANE_RIGHT_MIN_WIDTH = 28;
 const SINGLE_SELECT_SPLIT_PANE_SEPARATOR = " │ ";
 const FREEFORM_SENTINEL = "\u270f\ufe0f Type custom response...";
 const COMMENT_TOGGLE_LABEL = "Add extra context after selection";
+
+function buildCustomUIOptions(displayMode: AskDisplayMode) {
+   if (displayMode === "inline") {
+      return undefined;
+   }
+
+   return {
+      overlay: true,
+      overlayOptions: {
+         anchor: "center" as const,
+         width: ASK_OVERLAY_WIDTH,
+         minWidth: ASK_OVERLAY_MIN_WIDTH,
+         maxHeight: "85%",
+         margin: 1,
+      },
+   };
+}
 
 class MultiSelectList implements Component {
    private options: QuestionOption[];
@@ -1331,6 +1351,14 @@ export default function(pi: ExtensionAPI) {
          allowComment: Type.Optional(
             Type.Boolean({ description: "Collect an optional comment after selecting one or more options. Default: false" }),
          ),
+         displayMode: Type.Optional(
+            Type.Union([
+               Type.Literal("overlay"),
+               Type.Literal("inline"),
+            ], {
+               description: "UI rendering mode. 'overlay' shows a centered modal, 'inline' renders in-place. Default: overlay",
+            }),
+         ),
          timeout: Type.Optional(
             Type.Number({ description: "Auto-dismiss after N milliseconds. Returns null (cancelled) when expired." }),
          ),
@@ -1351,8 +1379,13 @@ export default function(pi: ExtensionAPI) {
             allowMultiple = false,
             allowFreeform = true,
             allowComment = false,
+            displayMode,
             timeout,
          } = params as AskParams;
+         const envMode = process.env.PI_ASK_USER_DISPLAY_MODE;
+         const envDisplayMode: AskDisplayMode | undefined =
+            envMode === "overlay" || envMode === "inline" ? envMode : undefined;
+         const effectiveDisplayMode: AskDisplayMode = displayMode ?? envDisplayMode ?? "overlay";
          const options = normalizeOptions(rawOptions);
          const normalizedContext = context?.trim() || undefined;
 
@@ -1399,41 +1432,34 @@ export default function(pi: ExtensionAPI) {
 
          let result: AskUIResult | null;
          try {
-            const customResult = await ctx.ui.custom<AskUIResult | null>(
-               (tui, theme, keybindings, done) => {
-                  if (signal) {
-                     const onAbort = () => done(null);
-                     signal.addEventListener("abort", onAbort, { once: true });
-                  }
+            const customFactory = (tui, theme, keybindings, done) => {
+               if (signal) {
+                  const onAbort = () => done(null);
+                  signal.addEventListener("abort", onAbort, { once: true });
+               }
 
-                  if (timeout && timeout > 0) {
-                     setTimeout(() => done(null), timeout);
-                  }
+               if (timeout && timeout > 0) {
+                  setTimeout(() => done(null), timeout);
+               }
 
-                  return new AskComponent(
-                     question,
-                     normalizedContext,
-                     options,
-                     allowMultiple,
-                     allowFreeform,
-                     allowComment,
-                     tui,
-                     theme,
-                     keybindings,
-                     done,
-                  );
-               },
-               {
-                  overlay: true,
-                  overlayOptions: {
-                     anchor: "center",
-                     width: ASK_OVERLAY_WIDTH,
-                     minWidth: ASK_OVERLAY_MIN_WIDTH,
-                     maxHeight: "85%",
-                     margin: 1,
-                  },
-               },
-            );
+               return new AskComponent(
+                  question,
+                  normalizedContext,
+                  options,
+                  allowMultiple,
+                  allowFreeform,
+                  allowComment,
+                  tui,
+                  theme,
+                  keybindings,
+                  done,
+               );
+            };
+
+            const customOptions = buildCustomUIOptions(effectiveDisplayMode);
+            const customResult = customOptions
+               ? await ctx.ui.custom<AskUIResult | null>(customFactory, customOptions)
+               : await ctx.ui.custom<AskUIResult | null>(customFactory);
 
             if (customResult !== undefined) {
                result = customResult;

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@
 
 import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
 import { getMarkdownTheme } from "@mariozechner/pi-coding-agent";
+import { StringEnum } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import {
    Container,
@@ -1352,10 +1353,7 @@ export default function(pi: ExtensionAPI) {
             Type.Boolean({ description: "Collect an optional comment after selecting one or more options. Default: false" }),
          ),
          displayMode: Type.Optional(
-            Type.Union([
-               Type.Literal("overlay"),
-               Type.Literal("inline"),
-            ], {
+            StringEnum(["overlay", "inline"] as const, {
                description: "UI rendering mode. 'overlay' shows a centered modal, 'inline' renders in-place. Default: overlay",
             }),
          ),
@@ -1432,7 +1430,7 @@ export default function(pi: ExtensionAPI) {
 
          let result: AskUIResult | null;
          try {
-            const customFactory = (tui, theme, keybindings, done) => {
+            const customFactory = (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: AskUIResult | null) => void) => {
                if (signal) {
                   const onAbort = () => done(null);
                   signal.addEventListener("abort", onAbort, { once: true });
@@ -1456,10 +1454,7 @@ export default function(pi: ExtensionAPI) {
                );
             };
 
-            const customOptions = buildCustomUIOptions(effectiveDisplayMode);
-            const customResult = customOptions
-               ? await ctx.ui.custom<AskUIResult | null>(customFactory, customOptions)
-               : await ctx.ui.custom<AskUIResult | null>(customFactory);
+            const customResult = await ctx.ui.custom<AskUIResult | null>(customFactory, buildCustomUIOptions(effectiveDisplayMode));
 
             if (customResult !== undefined) {
                result = customResult;

--- a/skills/ask-user/SKILL.md
+++ b/skills/ask-user/SKILL.md
@@ -54,7 +54,7 @@ Call `ask_user` with one decision at a time:
 - `options`: 2-5 clear choices when possible
 - `allowMultiple`: `false` unless independent selections are genuinely needed
 - `allowFreeform`: usually `true`
-
+- `displayMode` *(optional)*: `"overlay"` (default) or `"inline"`. Use `"inline"` when preceding assistant context (summary, trade-offs, recommendation) is essential to the decision and should remain visible — overlays cover the conversation underneath. The user may set a personal default via the `PI_ASK_USER_DISPLAY_MODE` environment variable; only pass this when you intentionally want to override it for one call.
 ### 5) Commit the decision
 After response:
 - restate the decision in plain language

--- a/skills/ask-user/references/ask-user-skill-extension-spec.md
+++ b/skills/ask-user/references/ask-user-skill-extension-spec.md
@@ -66,6 +66,19 @@ Use this protocol whenever the trigger matrix says to ask.
 }
 ```
 
+### Display mode (optional)
+
+The `ask_user` tool accepts an optional `displayMode` parameter:
+
+- `"overlay"` *(default)*: centered modal; covers the conversation underneath.
+- `"inline"`: rendered in the conversation flow; preceding messages stay visible.
+
+Guidance:
+
+- Omit `displayMode` to respect the user's configured preference (`PI_ASK_USER_DISPLAY_MODE` environment variable).
+- Pass `"inline"` only when the immediately preceding assistant message (summary, trade-offs, recommendation) is the primary context for the decision and must remain visible.
+- Pass `"overlay"` only to explicitly force the modal style (rare).
+
 ### Requirement-priority decision
 
 ```json


### PR DESCRIPTION
First — thank you for publishing `pi-ask-user`! It's been a really useful addition to my pi setup, and the decision-handshake skill in particular has shaped how I work with the agent.

### Motivation

When `ask_user` is invoked, the overlay covers the conversation underneath. In practice, the assistant message immediately preceding the question is often the most important context for the user's decision (summarized findings, options it considered, trade-offs, etc.). Hiding it behind a modal makes users dismiss/peek at the overlay or scroll context they can't see.

An inline render keeps the surrounding messages visible, so the user can answer in the flow of the conversation rather than against a covered backdrop.

### Changes

- Added a new optional tool parameter:
  - `displayMode: "overlay" | "inline"` (default: `"overlay"`)
  - `overlay` preserves current behavior
  - `inline` calls `ctx.ui.custom(...)` without overlay options
- Added a `PI_ASK_USER_DISPLAY_MODE` environment variable for a persistent personal default:
  - set to `"overlay"` or `"inline"` in your shell profile
  - unrecognised values are silently ignored and fall back to `"overlay"`
- Precedence: per-call `displayMode` → `PI_ASK_USER_DISPLAY_MODE` env var → `"overlay"`
- Introduced a small `buildCustomUIOptions(displayMode)` helper to keep the call site clean
- RPC/headless fallback path is unchanged
- Updated `README.md` (parameters table, example usage, personal preference section, inline behavior note)
- Updated bundled `ask-user` skill so the agent knows about `displayMode`:
  - added it to the payload field guidance in `SKILL.md`
  - added a "Display mode (optional)" subsection in `references/ask-user-skill-extension-spec.md` with guidance to omit by default and only override intentionally
- Added tests covering:
  - default remains overlay
  - `displayMode: "inline"` uses non-overlay custom UI path
  - `PI_ASK_USER_DISPLAY_MODE=inline` env var is honoured when no per-call value is set
  - per-call value overrides env var
  - invalid env var value falls back to `"overlay"`
  - cancellation/timeout still works in inline mode

### Notes

- Fully backward compatible — existing callers see no behavior change.
- Changes are intentionally minimal and scoped; happy to adjust naming, defaults, or split commits if you'd prefer a different shape.

Thanks again for maintaining this project!
