### PR TITLE
feat: alt+o runtime overlay hide/show toggle for ask_user (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `displayMode` parameter on `ask_user` (`"overlay"` | `"inline"`) controlling whether the custom UI renders as a centered modal or in the conversation flow
 - `PI_ASK_USER_DISPLAY_MODE` environment variable for setting a personal default display mode; per-call `displayMode` always wins over the env var, which always wins over the built-in `"overlay"` fallback
 - Skill guidance documenting when to override `displayMode` per call vs. respect the user's env-var preference
+- Runtime overlay toggle: in `overlay` mode, press `ctrl+o` while the prompt is open to temporarily hide/show the popup so you can read prior agent output. Press again to restore. Implemented via `OverlayHandle.setHidden()` and a global `ctx.ui.onTerminalInput` listener so the overlay can be revived even while hidden. A one-shot info notification on first hide reminds the user how to restore. Closes #11.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `displayMode` parameter on `ask_user` (`"overlay"` | `"inline"`) controlling whether the custom UI renders as a centered modal or in the conversation flow
 - `PI_ASK_USER_DISPLAY_MODE` environment variable for setting a personal default display mode; per-call `displayMode` always wins over the env var, which always wins over the built-in `"overlay"` fallback
 - Skill guidance documenting when to override `displayMode` per call vs. respect the user's env-var preference
-- Runtime overlay toggle: in `overlay` mode, press `ctrl+o` while the prompt is open to temporarily hide/show the popup so you can read prior agent output. Press again to restore. Implemented via `OverlayHandle.setHidden()` and a global `ctx.ui.onTerminalInput` listener so the overlay can be revived even while hidden. A one-shot info notification on first hide reminds the user how to restore. Closes #11.
+- Runtime overlay toggle: in `overlay` mode, press `alt+o` while the prompt is open to temporarily hide/show the popup so you can read prior agent output. Press again to restore. Implemented via `OverlayHandle.setHidden()` and a global `ctx.ui.onTerminalInput` listener so the overlay can be revived even while hidden. A one-shot info notification on first hide reminds the user how to restore. Closes #11.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ High-quality video: [ask-user-demo.mp4](./media/ask-user-demo.mp4)
 - User-toggleable extra context on structured selections
 - Context display support
 - Configurable display mode: `overlay` (modal, default) or `inline` (rendered directly in the flow)
-- Runtime overlay toggle: press `ctrl+o` while the prompt is open to temporarily hide/show the popup so you can read prior agent output, then press `ctrl+o` again to bring it back
+- Runtime overlay toggle: press `alt+o` while the prompt is open to temporarily hide/show the popup so you can read prior agent output, then press `alt+o` again to bring it back
 - Pi-TUI-aligned keybinding and editor behavior
 - Custom TUI rendering for tool calls and results
 - System prompt integration via `promptSnippet` and `promptGuidelines`
@@ -109,7 +109,7 @@ While an `ask_user` prompt is open:
 
 | Key | Action |
 |-----|--------|
-| `ctrl+o` | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you that `ctrl+o` brings it back. |
+| `alt+o` | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you that `alt+o` brings it back. |
 | `ctrl+g` | Toggle the optional comment/extra-context row (when `allowComment: true`). |
 | `enter` | Confirm the focused option, submit a freeform response, or submit/skip an optional comment. |
 | `esc` | Clear the search filter, exit freeform/comment mode, or cancel the prompt. |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ High-quality video: [ask-user-demo.mp4](./media/ask-user-demo.mp4)
 - User-toggleable extra context on structured selections
 - Context display support
 - Configurable display mode: `overlay` (modal, default) or `inline` (rendered directly in the flow)
+- Runtime overlay toggle: press `ctrl+o` while the prompt is open to temporarily hide/show the popup so you can read prior agent output, then press `ctrl+o` again to bring it back
 - Pi-TUI-aligned keybinding and editor behavior
 - Custom TUI rendering for tool calls and results
 - System prompt integration via `promptSnippet` and `promptGuidelines`
@@ -101,6 +102,20 @@ Effective behavior order:
 3. Fallback default: `"overlay"`
 
 Unrecognised values are silently ignored and fall back to `"overlay"`.
+
+## Controls
+
+While an `ask_user` prompt is open:
+
+| Key | Action |
+|-----|--------|
+| `ctrl+o` | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you that `ctrl+o` brings it back. |
+| `ctrl+g` | Toggle the optional comment/extra-context row (when `allowComment: true`). |
+| `enter` | Confirm the focused option, submit a freeform response, or submit/skip an optional comment. |
+| `esc` | Clear the search filter, exit freeform/comment mode, or cancel the prompt. |
+| `↑` / `↓` | Navigate options. |
+
+If you prefer never to see the overlay, set `displayMode: "inline"` per call or `PI_ASK_USER_DISPLAY_MODE=inline` globally.
 
 ## Result details
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -373,6 +373,192 @@ describe("ask_user", () => {
       expect(capturedOptions.overlay).toBe(true);
    });
 
+   describe("overlay hide/show toggle (ctrl+o)", () => {
+      function createOverlayHandle() {
+         let hidden = false;
+         const calls: boolean[] = [];
+         return {
+            handle: {
+               hide() { },
+               setHidden(value: boolean) {
+                  hidden = value;
+                  calls.push(value);
+               },
+               isHidden() {
+                  return hidden;
+               },
+               focus() { },
+               unfocus() { },
+               isFocused() {
+                  return false;
+               },
+            },
+            calls,
+         };
+      }
+
+      test("registers an onTerminalInput listener and passes onHandle in overlay mode", async () => {
+         const tool = await setupTool();
+         let capturedOptions: any;
+         let inputHandler: ((data: string) => any) | undefined;
+         let unsubscribed = false;
+
+         await tool.execute(
+            "tool-call-id",
+            { question: "Q", options: ["A"] },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (_factory: any, options: any) => {
+                     capturedOptions = options;
+                     return null;
+                  },
+                  onTerminalInput: (handler: (data: string) => any) => {
+                     inputHandler = handler;
+                     return () => {
+                        unsubscribed = true;
+                     };
+                  },
+                  notify: () => { },
+               },
+            },
+         );
+
+         expect(typeof capturedOptions.onHandle).toBe("function");
+         expect(typeof inputHandler).toBe("function");
+         expect(unsubscribed).toBe(true);
+      });
+
+      test("does not register onTerminalInput in inline mode", async () => {
+         const tool = await setupTool();
+         let registered = false;
+
+         await tool.execute(
+            "tool-call-id",
+            { question: "Q", options: ["A"], displayMode: "inline" },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async () => null,
+                  onTerminalInput: () => {
+                     registered = true;
+                     return () => { };
+                  },
+               },
+            },
+         );
+
+         expect(registered).toBe(false);
+      });
+
+      test("ctrl+o toggles overlay visibility via OverlayHandle.setHidden", async () => {
+         const tool = await setupTool();
+         const { handle, calls } = createOverlayHandle();
+         let inputHandler: ((data: string) => any) | undefined;
+         const notifications: Array<{ message: string; type?: string }> = [];
+
+         await tool.execute(
+            "tool-call-id",
+            { question: "Q", options: ["A"] },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (_factory: any, options: any) => {
+                     options.onHandle?.(handle);
+                     // Simulate the user pressing ctrl+o twice while the overlay is shown.
+                     const firstResult = inputHandler?.("ctrl+o");
+                     const secondResult = inputHandler?.("ctrl+o");
+                     expect(firstResult).toEqual({ consume: true });
+                     expect(secondResult).toEqual({ consume: true });
+                     return null;
+                  },
+                  onTerminalInput: (handler: (data: string) => any) => {
+                     inputHandler = handler;
+                     return () => { };
+                  },
+                  notify: (message: string, type?: string) => {
+                     notifications.push({ message, type });
+                  },
+               },
+            },
+         );
+
+         expect(calls).toEqual([true, false]);
+         expect(notifications).toHaveLength(1);
+         expect(notifications[0]?.message).toContain("ctrl+o");
+         expect(notifications[0]?.type).toBe("info");
+      });
+
+      test("ignores non-ctrl+o input from the terminal listener", async () => {
+         const tool = await setupTool();
+         const { handle, calls } = createOverlayHandle();
+         let inputHandler: ((data: string) => any) | undefined;
+
+         await tool.execute(
+            "tool-call-id",
+            { question: "Q", options: ["A"] },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (_factory: any, options: any) => {
+                     options.onHandle?.(handle);
+                     const result = inputHandler?.("a");
+                     expect(result).toBeUndefined();
+                     return null;
+                  },
+                  onTerminalInput: (handler: (data: string) => any) => {
+                     inputHandler = handler;
+                     return () => { };
+                  },
+                  notify: () => { },
+               },
+            },
+         );
+
+         expect(calls).toEqual([]);
+      });
+
+      test("restores a hidden overlay on completion", async () => {
+         const tool = await setupTool();
+         const { handle, calls } = createOverlayHandle();
+         let inputHandler: ((data: string) => any) | undefined;
+
+         await tool.execute(
+            "tool-call-id",
+            { question: "Q", options: ["A"] },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (_factory: any, options: any) => {
+                     options.onHandle?.(handle);
+                     // Hide and resolve while still hidden.
+                     inputHandler?.("ctrl+o");
+                     return null;
+                  },
+                  onTerminalInput: (handler: (data: string) => any) => {
+                     inputHandler = handler;
+                     return () => { };
+                  },
+                  notify: () => { },
+               },
+            },
+         );
+
+         // setHidden(true) from ctrl+o, then setHidden(false) from the finally block.
+         expect(calls).toEqual([true, false]);
+      });
+   });
+
    test("renders partial updates as waiting state instead of a successful empty answer", async () => {
       const tool = await setupTool();
       let partialUpdate: any;

--- a/index.test.ts
+++ b/index.test.ts
@@ -89,6 +89,7 @@ beforeAll(() => {
          space: "space",
          backspace: "backspace",
          ctrl: (key: string) => `ctrl+${key}`,
+         alt: (key: string) => `alt+${key}`,
          shift: (key: string) => `shift+${key}`,
          tab: "tab",
       },
@@ -373,7 +374,7 @@ describe("ask_user", () => {
       expect(capturedOptions.overlay).toBe(true);
    });
 
-   describe("overlay hide/show toggle (ctrl+o)", () => {
+   describe("overlay hide/show toggle (alt+o)", () => {
       function createOverlayHandle() {
          let hidden = false;
          const calls: boolean[] = [];
@@ -455,7 +456,7 @@ describe("ask_user", () => {
          expect(registered).toBe(false);
       });
 
-      test("ctrl+o toggles overlay visibility via OverlayHandle.setHidden", async () => {
+      test("alt+o toggles overlay visibility via OverlayHandle.setHidden", async () => {
          const tool = await setupTool();
          const { handle, calls } = createOverlayHandle();
          let inputHandler: ((data: string) => any) | undefined;
@@ -471,9 +472,9 @@ describe("ask_user", () => {
                ui: {
                   custom: async (_factory: any, options: any) => {
                      options.onHandle?.(handle);
-                     // Simulate the user pressing ctrl+o twice while the overlay is shown.
-                     const firstResult = inputHandler?.("ctrl+o");
-                     const secondResult = inputHandler?.("ctrl+o");
+                     // Simulate the user pressing alt+o twice while the overlay is shown.
+                     const firstResult = inputHandler?.("alt+o");
+                     const secondResult = inputHandler?.("alt+o");
                      expect(firstResult).toEqual({ consume: true });
                      expect(secondResult).toEqual({ consume: true });
                      return null;
@@ -491,11 +492,11 @@ describe("ask_user", () => {
 
          expect(calls).toEqual([true, false]);
          expect(notifications).toHaveLength(1);
-         expect(notifications[0]?.message).toContain("ctrl+o");
+         expect(notifications[0]?.message).toContain("alt+o");
          expect(notifications[0]?.type).toBe("info");
       });
 
-      test("ignores non-ctrl+o input from the terminal listener", async () => {
+      test("does not consume ctrl+o from the terminal listener", async () => {
          const tool = await setupTool();
          const { handle, calls } = createOverlayHandle();
          let inputHandler: ((data: string) => any) | undefined;
@@ -510,7 +511,7 @@ describe("ask_user", () => {
                ui: {
                   custom: async (_factory: any, options: any) => {
                      options.onHandle?.(handle);
-                     const result = inputHandler?.("a");
+                     const result = inputHandler?.("ctrl+o");
                      expect(result).toBeUndefined();
                      return null;
                   },
@@ -526,7 +527,7 @@ describe("ask_user", () => {
          expect(calls).toEqual([]);
       });
 
-      test("restores a hidden overlay on completion", async () => {
+      test("does not force a hidden overlay visible during cleanup", async () => {
          const tool = await setupTool();
          const { handle, calls } = createOverlayHandle();
          let inputHandler: ((data: string) => any) | undefined;
@@ -542,7 +543,7 @@ describe("ask_user", () => {
                   custom: async (_factory: any, options: any) => {
                      options.onHandle?.(handle);
                      // Hide and resolve while still hidden.
-                     inputHandler?.("ctrl+o");
+                     inputHandler?.("alt+o");
                      return null;
                   },
                   onTerminalInput: (handler: (data: string) => any) => {
@@ -554,8 +555,7 @@ describe("ask_user", () => {
             },
          );
 
-         // setHidden(true) from ctrl+o, then setHidden(false) from the finally block.
-         expect(calls).toEqual([true, false]);
+         expect(calls).toEqual([true]);
       });
    });
 
@@ -951,6 +951,7 @@ describe("ask_user", () => {
       );
 
       expect(result.isError).not.toBe(true);
+      expect(helpText).toContain("alt+o hide");
       expect(helpText).toContain("q cancel");
       expect(helpText).not.toContain("ctrl+c cancel");
    });

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import {
    Markdown,
    type MarkdownTheme,
    matchesKey,
+   type OverlayHandle,
    Spacer,
    Text,
    type TUI,
@@ -248,6 +249,10 @@ function isCommentToggleKey(data: string): boolean {
    return matchesKey(data, Key.ctrl("g"));
 }
 
+function isOverlayHideToggleKey(data: string): boolean {
+   return matchesKey(data, Key.ctrl("o"));
+}
+
 type AskMode = "select" | "freeform" | "comment";
 
 const ASK_OVERLAY_MAX_HEIGHT_RATIO = 0.85;
@@ -260,7 +265,10 @@ const SINGLE_SELECT_SPLIT_PANE_SEPARATOR = " │ ";
 const FREEFORM_SENTINEL = "\u270f\ufe0f Type custom response...";
 const COMMENT_TOGGLE_LABEL = "Add extra context after selection";
 
-function buildCustomUIOptions(displayMode: AskDisplayMode) {
+function buildCustomUIOptions(
+   displayMode: AskDisplayMode,
+   onHandle?: (handle: OverlayHandle) => void,
+) {
    switch (displayMode) {
       case "inline":
          return undefined;
@@ -274,6 +282,7 @@ function buildCustomUIOptions(displayMode: AskDisplayMode) {
                maxHeight: "85%",
                margin: 1,
             },
+            ...(onHandle ? { onHandle } : {}),
          };
       default: {
          const _exhaustive: never = displayMode;
@@ -287,6 +296,7 @@ function buildCustomUIOptions(displayMode: AskDisplayMode) {
                maxHeight: "85%",
                margin: 1,
             },
+            ...(onHandle ? { onHandle } : {}),
          };
       }
    }
@@ -868,6 +878,7 @@ class AskComponent extends Container {
    private allowMultiple: boolean;
    private allowFreeform: boolean;
    private allowComment: boolean;
+   private displayMode: AskDisplayMode;
    private tui: TUI;
    private theme: Theme;
    private keybindings: KeybindingsManager;
@@ -909,6 +920,7 @@ class AskComponent extends Container {
       allowMultiple: boolean,
       allowFreeform: boolean,
       allowComment: boolean,
+      displayMode: AskDisplayMode,
       tui: TUI,
       theme: Theme,
       keybindings: KeybindingsManager,
@@ -922,6 +934,7 @@ class AskComponent extends Container {
       this.allowMultiple = allowMultiple;
       this.allowFreeform = allowFreeform;
       this.allowComment = allowComment;
+      this.displayMode = displayMode;
       this.tui = tui;
       this.theme = theme;
       this.keybindings = keybindings;
@@ -1044,6 +1057,9 @@ class AskComponent extends Container {
 
    private updateHelpText(): void {
       const theme = this.theme;
+      const overlayHint = this.displayMode === "overlay"
+         ? literalHint(theme, "ctrl+o", "hide")
+         : null;
       if (this.mode === "freeform" || this.mode === "comment") {
          const alternateCancelKeys = this.keybindings
             .getKeys("tui.select.cancel")
@@ -1052,6 +1068,7 @@ class AskComponent extends Container {
             keybindingHint(theme, this.keybindings, "tui.input.submit", this.mode === "comment" ? "submit/skip" : "submit"),
             keybindingHint(theme, this.keybindings, "tui.input.newLine", "newline"),
             literalHint(theme, "esc", "back"),
+            overlayHint,
             alternateCancelKeys.length > 0 ? literalHint(theme, formatKeyList(alternateCancelKeys), "cancel") : null,
          ]
             .filter((hint): hint is string => !!hint)
@@ -1065,6 +1082,7 @@ class AskComponent extends Container {
             literalHint(theme, "↑↓", "navigate"),
             literalHint(theme, "space", "toggle"),
             this.allowComment ? literalHint(theme, "ctrl+g", "toggle context") : null,
+            overlayHint,
             keybindingHint(theme, this.keybindings, "tui.select.confirm", "submit"),
             keybindingHint(theme, this.keybindings, "tui.select.cancel", "cancel"),
          ]
@@ -1080,6 +1098,7 @@ class AskComponent extends Container {
             keybindingHint(theme, this.keybindings, "tui.editor.deleteCharBackward", "erase"),
             literalHint(theme, "↑↓", "navigate"),
             this.allowComment ? literalHint(theme, "ctrl+g", "toggle context") : null,
+            overlayHint,
             keybindingHint(theme, this.keybindings, "tui.select.confirm", "select"),
             literalHint(theme, "esc", "clear/cancel"),
             alternateCancelKeys.length > 0
@@ -1461,6 +1480,9 @@ export default function(pi: ExtensionAPI) {
          });
 
          let result: AskUIResult | null;
+         let overlayHandle: OverlayHandle | undefined;
+         let removeOverlayInputListener: (() => void) | undefined;
+         let hasAnnouncedHide = false;
          try {
             const customFactory = (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: AskUIResult | null) => void) => {
                if (signal) {
@@ -1479,6 +1501,7 @@ export default function(pi: ExtensionAPI) {
                   allowMultiple,
                   allowFreeform,
                   allowComment,
+                  effectiveDisplayMode,
                   tui,
                   theme,
                   keybindings,
@@ -1486,7 +1509,28 @@ export default function(pi: ExtensionAPI) {
                );
             };
 
-            const customResult = await ctx.ui.custom<AskUIResult | null>(customFactory, buildCustomUIOptions(effectiveDisplayMode));
+            // Register a raw terminal input listener for ctrl+o so the overlay can be
+            // toggled even while it is hidden (hidden overlays do not receive input).
+            // Inline mode does not need this because the prompt is already non-modal.
+            if (effectiveDisplayMode === "overlay" && typeof ctx.ui.onTerminalInput === "function") {
+               removeOverlayInputListener = ctx.ui.onTerminalInput((data) => {
+                  if (!isOverlayHideToggleKey(data) || !overlayHandle) return undefined;
+                  const nextHidden = !overlayHandle.isHidden();
+                  overlayHandle.setHidden(nextHidden);
+                  if (nextHidden && !hasAnnouncedHide) {
+                     hasAnnouncedHide = true;
+                     ctx.ui.notify?.("ask_user hidden — press ctrl+o to reopen", "info");
+                  }
+                  return { consume: true };
+               });
+            }
+
+            const customResult = await ctx.ui.custom<AskUIResult | null>(
+               customFactory,
+               buildCustomUIOptions(effectiveDisplayMode, (handle) => {
+                  overlayHandle = handle;
+               }),
+            );
 
             if (customResult !== undefined) {
                result = customResult;
@@ -1502,6 +1546,11 @@ export default function(pi: ExtensionAPI) {
                isError: true,
                details: { error: message },
             };
+         } finally {
+            if (overlayHandle?.isHidden()) {
+               overlayHandle.setHidden(false);
+            }
+            removeOverlayInputListener?.();
          }
 
          if (result === null) {

--- a/index.ts
+++ b/index.ts
@@ -250,7 +250,7 @@ function isCommentToggleKey(data: string): boolean {
 }
 
 function isOverlayHideToggleKey(data: string): boolean {
-   return matchesKey(data, Key.ctrl("o"));
+   return matchesKey(data, Key.alt("o"));
 }
 
 type AskMode = "select" | "freeform" | "comment";
@@ -264,6 +264,7 @@ const SINGLE_SELECT_SPLIT_PANE_RIGHT_MIN_WIDTH = 28;
 const SINGLE_SELECT_SPLIT_PANE_SEPARATOR = " │ ";
 const FREEFORM_SENTINEL = "\u270f\ufe0f Type custom response...";
 const COMMENT_TOGGLE_LABEL = "Add extra context after selection";
+const OVERLAY_HIDE_TOGGLE_LABEL = "alt+o";
 
 function buildCustomUIOptions(
    displayMode: AskDisplayMode,
@@ -1058,7 +1059,7 @@ class AskComponent extends Container {
    private updateHelpText(): void {
       const theme = this.theme;
       const overlayHint = this.displayMode === "overlay"
-         ? literalHint(theme, "ctrl+o", "hide")
+         ? literalHint(theme, OVERLAY_HIDE_TOGGLE_LABEL, "hide")
          : null;
       if (this.mode === "freeform" || this.mode === "comment") {
          const alternateCancelKeys = this.keybindings
@@ -1509,7 +1510,7 @@ export default function(pi: ExtensionAPI) {
                );
             };
 
-            // Register a raw terminal input listener for ctrl+o so the overlay can be
+            // Register a raw terminal input listener for alt+o so the overlay can be
             // toggled even while it is hidden (hidden overlays do not receive input).
             // Inline mode does not need this because the prompt is already non-modal.
             if (effectiveDisplayMode === "overlay" && typeof ctx.ui.onTerminalInput === "function") {
@@ -1519,7 +1520,7 @@ export default function(pi: ExtensionAPI) {
                   overlayHandle.setHidden(nextHidden);
                   if (nextHidden && !hasAnnouncedHide) {
                      hasAnnouncedHide = true;
-                     ctx.ui.notify?.("ask_user hidden — press ctrl+o to reopen", "info");
+                     ctx.ui.notify?.(`ask_user hidden — press ${OVERLAY_HIDE_TOGGLE_LABEL} to reopen`, "info");
                   }
                   return { consume: true };
                });
@@ -1547,9 +1548,6 @@ export default function(pi: ExtensionAPI) {
                details: { error: message },
             };
          } finally {
-            if (overlayHandle?.isHidden()) {
-               overlayHandle.setHidden(false);
-            }
             removeOverlayInputListener?.();
          }
 


### PR DESCRIPTION
Closes #11.

Adds a runtime keybinding to temporarily hide the `ask_user` overlay so the user can read the agent's prior output for context, then restore the prompt without losing selection or draft state.

## Final behavior

- `alt+o` hides and re-shows the `ask_user` overlay in `displayMode: "overlay"`.
- Pi's built-in `ctrl+o` tool-output expansion remains untouched.
- The implementation uses `ctx.ui.onTerminalInput(...)` so a hidden overlay can still be reopened even though hidden overlays do not receive focused input.
- Selection state, search query, freeform draft, and comment draft are preserved across hide/show.
- The first hide shows a one-shot info notification explaining how to reopen the prompt.
- Cleanup only unregisters the listener; it does not force a hidden overlay visible again, avoiding stale overlay-handle refocus after timeout/cancel/close.
- `displayMode: "inline"` is unchanged.

## Tests

- listener subscribe/unsubscribe lifecycle in overlay mode
- no terminal listener registration in inline mode
- `alt+o` toggles overlay visibility and emits a single notification on first hide
- `ctrl+o` is not consumed by the overlay listener
- hidden overlay cleanup does not force the overlay visible again
- help text includes `alt+o hide`

Validation:

- `bun test`
- `bun run check`

## Files

- `index.ts` — overlay toggle keybinding, help text, notification text, cleanup fix
- `index.test.ts` — regression coverage for shortcut collision and hidden-overlay teardown
- `README.md` — updated controls/docs to `alt+o`
- `CHANGELOG.md` — unreleased entry updated to `alt+o`
