### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.9.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.9.0) - Unreleased
+## [0.9.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.9.0) - 2026-05-04
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-ask-user",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Interactive ask_user tool for pi-coding-agent with searchable split-pane selection UI, multi-select, and freeform input",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Bumps version to 0.9.0 and dates the changelog entry for the configurable-shortcuts feature merged in #14.