### PR TITLE
feat: declare ask_user executionMode "sequential"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.11.2](https://github.com/edlsh/pi-ask-user/releases/tag/v0.11.2) - 2026-06-03
+
+### Changed
+
+- Declare `executionMode: "sequential"` on the `ask_user` tool so the agent loop awaits the user's answer before running any other tool call in the same assistant turn. Without this, hosts running the default `"parallel"` tool-execution mode could batch `ask_user` with `bash`/`edit`/`write` calls and let those execute — potentially with irreversible side effects — before the user even sees the prompt. Requires no peer-dep bump; `executionMode` has been part of `ToolDefinition` since `@earendil-works/pi-coding-agent@0.74.0`.
+
 ## [0.11.1](https://github.com/edlsh/pi-ask-user/releases/tag/v0.11.1) - 2026-05-23
 
 ### Fixed

--- a/index.test.ts
+++ b/index.test.ts
@@ -204,6 +204,11 @@ function createTheme() {
 }
 
 describe("ask_user", () => {
+   test("registers with executionMode 'sequential' so the agent loop awaits the user's answer before other tool calls run", async () => {
+      const tool = await setupTool();
+      expect((tool as any).executionMode).toBe("sequential");
+   });
+
    test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;

--- a/index.ts
+++ b/index.ts
@@ -1487,6 +1487,10 @@ export default function(pi: ExtensionAPI) {
          "Ask exactly one focused question per ask_user call.",
          "Do not combine multiple numbered, multipart, or unrelated questions into one ask_user prompt.",
       ],
+      // Block other tool calls in the same assistant turn until the user answers,
+      // so the model can't batch ask_user with bash/edit/write and let those run
+      // (potentially with side effects) before the user sees the prompt.
+      executionMode: "sequential",
       parameters: Type.Object({
          question: Type.String({ description: "The question to ask the user" }),
          context: Type.Optional(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-ask-user",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Interactive ask_user tool for pi-coding-agent with searchable split-pane selection UI, multi-select, and freeform input",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

Adopt `executionMode: "sequential"` on the `ask_user` tool so the agent loop awaits the user's answer before running any other tool call in the same assistant turn.

## Why

`ask_user` blocks on human input. Without `executionMode`, hosts running the default `"parallel"` tool-execution mode could batch `ask_user` with `bash`/`edit`/`write` calls in one assistant turn and let those execute — potentially with irreversible side effects — before the user even sees the prompt. `sequential` forces the loop to incorporate the user's answer into the next turn before anything else runs.

## What changed

| File | Change |
| --- | --- |
| `index.ts` | +4 lines: `executionMode: "sequential"` on the `pi.registerTool({...})` literal, with a rationale comment |
| `index.test.ts` | +5 lines: one assertion test guarding the contract |
| `package.json` | version bump `0.11.1` → `0.11.2` |
| `CHANGELOG.md` | new 0.11.2 entry |

## Compatibility

No peer-dep bump. `executionMode` has been part of `ToolDefinition` in `@earendil-works/pi-coding-agent` since `0.74.0` (verified against the published tarball), which matches our existing floor.

## Verification

- `bun test` → **56 pass, 0 fail** (up from 55 — the new assertion test runs and passes)
- `npm pack --dry-run` → clean, packs as `pi-ask-user-0.11.2.tgz`