### PR TITLE
feat: add external ask_user responder bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add an optional process-local external responder bridge for companion Pi extensions. `ask_user` now emits `ask:prompt` with normalized prompt metadata plus idempotent `respond` / `resolve` callbacks, then emits `ask:answered` or `ask:cancelled` when either the local UI or an external responder settles the prompt. This lets integrations mirror and answer prompts without importing `pi-ask-user` internals or adding a direct package dependency.
+
+### Fixed
+
+- Pass an abort signal into RPC/dialog fallback prompts so hosts that support `signal` can cancel pending `select()` / `input()` prompts after agent aborts or external responses.
+
 ## [0.11.2](https://github.com/edlsh/pi-ask-user/releases/tag/v0.11.2) - 2026-06-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -182,8 +182,17 @@ type ExternalAskPromptEvent = {
 ```
 
 The first answer wins. If the external surface calls `respond(...)` first, the
-local prompt closes and the tool returns a normal `ask_user` result. If the local
-TUI answers first, later external calls return `false`.
+tool returns a normal `ask_user` result, and the rich local custom UI is closed
+through its completion callback. RPC dialog fallbacks (`select()` / `input()`)
+may remain visible if the host UI API does not support programmatic
+cancellation. If the local UI answers first, later external calls return
+`false`.
+
+External responses must use the normalized `AskResponse` shape and respect the
+prompt flags: freeform answers require `allowFreeform` (except no-option
+prompts), single-select prompts accept one selection, selections must match the
+provided option titles, and comments are only retained when `allowComment` is
+true. Invalid external responses return `false` without settling the prompt.
 
 ### `ask:answered` / `ask:cancelled`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ High-quality video: [ask-user-demo.mp4](./media/ask-user-demo.mp4)
 - Custom TUI rendering for tool calls and results
 - System prompt integration via `promptSnippet` and `promptGuidelines`
 - Optional timeout for auto-dismiss in both overlay and fallback input modes
+- Process-local external responder bridge for companion extensions that mirror prompts to another UI
 - Structured `details` on all results for session state reconstruction
 - Graceful fallback when interactive UI is unavailable
 - Bundled `ask-user` skill for mandatory decision-gating in high-stakes or ambiguous tasks
@@ -155,8 +156,9 @@ interface AskToolDetails {
 
 Integrations that run inside the same Pi process can mirror an `ask_user` prompt
 in another surface (for example a mobile app, chat bridge, or web UI) without
-replacing the local TUI. The extension emits process-local events on
-`pi.events`:
+replacing the local TUI and without importing `pi-ask-user` internals. The
+extension emits process-local events on `pi.events`; consumers should treat the
+payloads structurally and feature-detect the bridge at runtime:
 
 ### `ask:prompt`
 
@@ -184,9 +186,10 @@ type ExternalAskPromptEvent = {
 The first answer wins. If the external surface calls `respond(...)` first, the
 tool returns a normal `ask_user` result, and the rich local custom UI is closed
 through its completion callback. RPC dialog fallbacks (`select()` / `input()`)
-may remain visible if the host UI API does not support programmatic
-cancellation. If the local UI answers first, later external calls return
-`false`.
+receive an abort signal that follows both the active agent abort signal and an
+external response, so hosts that honor `signal` can programmatically cancel those
+prompts; hosts that ignore `signal` may still keep their fallback dialog visible.
+If the local UI answers first, later external calls return `false`.
 
 External responses must use the normalized `AskResponse` shape and respect the
 prompt flags: freeform answers require `allowFreeform` (except no-option
@@ -212,6 +215,25 @@ pi.events.on("ask:cancelled", (event) => {
 These events are intentionally in-process callbacks, not a serializable wire
 protocol. Bridge extensions should translate them into their own transport
 format when forwarding prompts to another device or service.
+
+Minimal consumer pattern:
+
+```typescript
+pi.events.on("ask:prompt", (raw) => {
+  if (!raw || typeof raw !== "object") return;
+  const event = raw as {
+    toolCallId?: unknown;
+    question?: unknown;
+    respond?: unknown;
+  };
+  if (typeof event.toolCallId !== "string") return;
+  if (typeof event.question !== "string") return;
+  if (typeof event.respond !== "function") return;
+
+  // Mirror the prompt to another UI. Later, if that UI answers first:
+  event.respond({ kind: "freeform", text: "Use the safer option" });
+});
+```
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All tool results include a structured `details` object for rendering and session
 ```typescript
 type AskResponse =
   | { kind: "selection"; selections: string[]; comment?: string }
-  | { kind: "freeform"; text: string };
+  | { kind: "freeform"; text: string; comment?: string };
 
 interface AskToolDetails {
   question: string;
@@ -150,6 +150,59 @@ interface AskToolDetails {
   cancelled: boolean;
 }
 ```
+
+## External prompt responder events
+
+Integrations that run inside the same Pi process can mirror an `ask_user` prompt
+in another surface (for example a mobile app, chat bridge, or web UI) without
+replacing the local TUI. The extension emits process-local events on
+`pi.events`:
+
+### `ask:prompt`
+
+Emitted after input normalization and before the local prompt is answered.
+
+```typescript
+type ExternalAskPromptEvent = {
+  toolCallId: string;
+  question: string;
+  context?: string;
+  options: QuestionOption[];
+  allowMultiple: boolean;
+  allowFreeform: boolean;
+  allowComment: boolean;
+
+  // Resolve the prompt from the external surface. Pass null to cancel.
+  // Returns false if the prompt already settled locally or externally.
+  respond(result: AskResponse | null): boolean;
+
+  // Alias for respond(), kept for integrations that use resolve naming.
+  resolve(result: AskResponse | null): boolean;
+};
+```
+
+The first answer wins. If the external surface calls `respond(...)` first, the
+local prompt closes and the tool returns a normal `ask_user` result. If the local
+TUI answers first, later external calls return `false`.
+
+### `ask:answered` / `ask:cancelled`
+
+Emitted when the local or external answer is finalized, so mirrored UIs can mark
+their prompt as answered or cancelled:
+
+```typescript
+pi.events.on("ask:answered", (event) => {
+  // { toolCallId, question, context, response }
+});
+
+pi.events.on("ask:cancelled", (event) => {
+  // { toolCallId, question, context, options }
+});
+```
+
+These events are intentionally in-process callbacks, not a serializable wire
+protocol. Bridge extensions should translate them into their own transport
+format when forwarding prompts to another device or service.
 
 ## Changelog
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -352,6 +352,168 @@ describe("ask_user", () => {
       expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"] })).toBe(false);
    });
 
+   test("external responder returns false after custom() directly returns a local answer", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async () => ({ kind: "selection", selections: ["A"] }),
+            },
+         },
+      );
+
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["A"] });
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"] })).toBe(false);
+   });
+
+   test("external responder returns false after custom() directly cancels", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async () => null,
+            },
+         },
+      );
+
+      expect(result.details.cancelled).toBe(true);
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"] })).toBe(false);
+   });
+
+   test("external cancellation resolves as a cancelled ask_user result", async () => {
+      const tool = await setupTool();
+      let doneCallback: ((result: any) => void) | undefined;
+
+      const pending = tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => new Promise((resolve) => {
+                  doneCallback = resolve;
+                  factory(
+                     { terminal: { rows: 30 }, requestRender: () => undefined },
+                     createTheme(),
+                     createKeybindings(),
+                     resolve,
+                  );
+               }),
+               onTerminalInput: () => () => undefined,
+               notify: () => undefined,
+            },
+         },
+      );
+
+      expect(doneCallback).toBeDefined();
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload.respond(null)).toBe(true);
+
+      const result = await pending;
+      expect(result.details.cancelled).toBe(true);
+      expect(result.details.response).toBeNull();
+      const cancelledEvent = emittedEvents.find((event) => event.name === "ask:cancelled");
+      expect(cancelledEvent?.payload.toolCallId).toBe("tool-call-id");
+   });
+
+   test("resolve alias behaves like respond for external answers", async () => {
+      const tool = await setupTool();
+
+      const pending = tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => new Promise((resolve) => {
+                  factory(
+                     { terminal: { rows: 30 }, requestRender: () => undefined },
+                     createTheme(),
+                     createKeybindings(),
+                     resolve,
+                  );
+               }),
+               onTerminalInput: () => () => undefined,
+               notify: () => undefined,
+            },
+         },
+      );
+
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload.resolve({ kind: "selection", selections: ["B"] })).toBe(true);
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["A"] })).toBe(false);
+
+      const result = await pending;
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["B"] });
+   });
+
+   test("external responder rejects invalid responses without settling", async () => {
+      const tool = await setupTool();
+
+      const pending = tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+            allowFreeform: false,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => new Promise((resolve) => {
+                  factory(
+                     { terminal: { rows: 30 }, requestRender: () => undefined },
+                     createTheme(),
+                     createKeybindings(),
+                     resolve,
+                  );
+               }),
+               onTerminalInput: () => () => undefined,
+               notify: () => undefined,
+            },
+         },
+      );
+
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload.respond({ kind: "freeform", text: "not allowed" })).toBe(false);
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"] })).toBe(true);
+
+      const result = await pending;
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["B"] });
+   });
+
    test("uses non-overlay custom UI when displayMode is inline", async () => {
       const tool = await setupTool();
       let capturedOptions: any;
@@ -1973,6 +2135,70 @@ describe("ask_user", () => {
          expect(result.isError).not.toBe(true);
          expect(inputCalled).toBe(true);
          expect(result.details.response).toEqual({ kind: "freeform", text: "Purple" });
+      });
+
+      test("empty options fall back directly to input()", async () => {
+         const tool = await setupTool();
+         let inputTitle = "";
+         let selectCalled = false;
+
+         const result = await tool.execute(
+            "tool-call-id",
+            {
+               question: "What should we do?",
+            },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async () => undefined,
+                  select: async () => {
+                     selectCalled = true;
+                     return undefined;
+                  },
+                  input: async (title: string) => {
+                     inputTitle = title;
+                     return "Ship it";
+                  },
+               },
+            },
+         );
+
+         expect(result.isError).not.toBe(true);
+         expect(selectCalled).toBe(false);
+         expect(inputTitle).toContain("What should we do?");
+         expect(result.details.response).toEqual({ kind: "freeform", text: "Ship it" });
+      });
+
+      test("empty options still use direct input when allowFreeform is false", async () => {
+         const tool = await setupTool();
+         let selectCalled = false;
+
+         const result = await tool.execute(
+            "tool-call-id",
+            {
+               question: "What should we do?",
+               allowFreeform: false,
+            },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async () => undefined,
+                  select: async () => {
+                     selectCalled = true;
+                     return undefined;
+                  },
+                  input: async () => "Still answer freely",
+               },
+            },
+         );
+
+         expect(result.isError).not.toBe(true);
+         expect(selectCalled).toBe(false);
+         expect(result.details.response).toEqual({ kind: "freeform", text: "Still answer freely" });
       });
 
       test("multi-select degrades to input() with options in prompt", async () => {

--- a/index.test.ts
+++ b/index.test.ts
@@ -172,7 +172,7 @@ function stubEnv(key: string, value: string): void {
    });
 }
 
-async function setupTool(): Promise<RegisteredTool> {
+async function setupTool(onEmit?: (name: string, payload: any) => void): Promise<RegisteredTool> {
    const { default: askUserExtension } = await import("./index");
    let registeredTool: RegisteredTool | undefined;
    emittedEvents = [];
@@ -183,6 +183,7 @@ async function setupTool(): Promise<RegisteredTool> {
       events: {
          emit(name: string, payload: any) {
             emittedEvents.push({ name, payload });
+            onEmit?.(name, payload);
          },
       },
    } as any;
@@ -291,6 +292,12 @@ describe("ask_user", () => {
 
    test("external responder can win the RPC dialog fallback race", async () => {
       const tool = await setupTool();
+      let fallbackSignal: AbortSignal | undefined;
+      let fallbackAborted = false;
+      let markSelectStarted!: () => void;
+      const selectStarted = new Promise<void>((resolve) => {
+         markSelectStarted = resolve;
+      });
 
       const pending = tool.execute(
          "tool-call-id",
@@ -305,16 +312,28 @@ describe("ask_user", () => {
             hasUI: true,
             ui: {
                custom: async () => undefined,
-               select: async () => new Promise(() => undefined),
+               select: async (_title: string, _opts: string[], opts: any) => {
+                  fallbackSignal = opts?.signal;
+                  markSelectStarted();
+                  return new Promise((resolve) => {
+                     opts?.signal?.addEventListener("abort", () => {
+                        fallbackAborted = true;
+                        resolve(undefined);
+                     }, { once: true });
+                  });
+               },
                input: async () => undefined,
             },
          },
       );
 
+      await selectStarted;
       const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
       expect(promptEvent?.payload.respond({ kind: "selection", selections: ["Blue"] })).toBe(true);
 
       const result = await pending;
+      expect(fallbackSignal).toBeDefined();
+      expect(fallbackAborted).toBe(true);
       expect(result.details.response).toEqual({ kind: "selection", selections: ["Blue"] });
    });
 
@@ -486,6 +505,7 @@ describe("ask_user", () => {
             question: "Which option should we use?",
             options: ["A", "B"],
             allowFreeform: false,
+            allowComment: true,
          },
          undefined,
          undefined,
@@ -508,9 +528,89 @@ describe("ask_user", () => {
 
       const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
       expect(promptEvent?.payload.respond({ kind: "freeform", text: "not allowed" })).toBe(false);
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"], comment: 42 })).toBe(false);
       expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"] })).toBe(true);
 
       const result = await pending;
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["B"] });
+   });
+
+   test("skips RPC dialogs when a synchronous external responder has already settled", async () => {
+      const tool = await setupTool((name, payload) => {
+         if (name === "ask:prompt") {
+            expect(payload.respond({ kind: "selection", selections: ["Blue"] })).toBe(true);
+         }
+      });
+      let dialogStarted = false;
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick a color",
+            options: ["Red", "Blue"],
+            allowFreeform: false,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async () => undefined,
+               select: async () => {
+                  dialogStarted = true;
+                  return "Red";
+               },
+               input: async () => undefined,
+            },
+         },
+      );
+
+      expect(dialogStarted).toBe(false);
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["Blue"] });
+   });
+
+   test("does not register rich UI abort or timeout handlers after a synchronous external response", async () => {
+      const tool = await setupTool((name, payload) => {
+         if (name === "ask:prompt") {
+            expect(payload.respond({ kind: "selection", selections: ["B"] })).toBe(true);
+         }
+      });
+      let addAbortListenerCalls = 0;
+      const signal = {
+         aborted: false,
+         addEventListener() {
+            addAbortListenerCalls += 1;
+         },
+         removeEventListener() { },
+      };
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+            timeout: 5000,
+         },
+         signal,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => new Promise((resolve) => {
+                  factory(
+                     { terminal: { rows: 30 }, requestRender: () => undefined },
+                     createTheme(),
+                     createKeybindings(),
+                     resolve,
+                  );
+               }),
+               onTerminalInput: () => () => undefined,
+               notify: () => undefined,
+            },
+         },
+      );
+
+      expect(addAbortListenerCalls).toBe(0);
       expect(result.details.response).toEqual({ kind: "selection", selections: ["B"] });
    });
 
@@ -2355,7 +2455,56 @@ describe("ask_user", () => {
             },
          );
 
-         expect(capturedOpts).toEqual({ timeout: 5000 });
+         expect(capturedOpts).toMatchObject({ timeout: 5000 });
+         expect(capturedOpts.signal).toBeDefined();
+      });
+
+      test("passes the abort signal to dialog methods so RPC fallback prompts can cancel", async () => {
+         const tool = await setupTool();
+         const controller = new AbortController();
+         let capturedSignal: AbortSignal | undefined;
+         let markSelectStarted!: () => void;
+         const selectStarted = new Promise<void>((resolve) => {
+            markSelectStarted = resolve;
+         });
+
+         const pending = tool.execute(
+            "tool-call-id",
+            {
+               question: "Pick a color",
+               options: ["Red", "Blue"],
+               allowFreeform: false,
+            },
+            controller.signal,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async () => undefined,
+                  select: async (_title: string, _opts: string[], opts: any) => {
+                     capturedSignal = opts?.signal;
+                     markSelectStarted();
+                     return new Promise((resolve) => {
+                        opts?.signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+                     });
+                  },
+                  input: async () => undefined,
+               },
+            },
+         );
+
+         await selectStarted;
+         controller.abort();
+
+         const result = await Promise.race([
+            pending,
+            new Promise((resolve) => setTimeout(() => resolve("timed out"), 25)),
+         ]);
+
+         expect(capturedSignal).toBeDefined();
+         expect(capturedSignal?.aborted).toBe(true);
+         expect(result).not.toBe("timed out");
+         expect((result as any).details.cancelled).toBe(true);
       });
    });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -236,6 +236,122 @@ describe("ask_user", () => {
       expect(capturedOptions.overlayOptions.visible).toBeUndefined();
    });
 
+   test("emits ask:prompt and lets an external responder answer the rich UI", async () => {
+      const tool = await setupTool();
+      let doneCallback: ((result: any) => void) | undefined;
+
+      const pending = tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            context: "Need a decision",
+            options: ["A", "B"],
+            allowComment: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => new Promise((resolve) => {
+                  doneCallback = resolve;
+                  factory(
+                     { terminal: { rows: 30 }, requestRender: () => undefined },
+                     createTheme(),
+                     createKeybindings(),
+                     resolve,
+                  );
+               }),
+               onTerminalInput: () => () => undefined,
+               notify: () => undefined,
+            },
+         },
+      );
+
+      expect(doneCallback).toBeDefined();
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload).toMatchObject({
+         toolCallId: "tool-call-id",
+         question: "Which option should we use?",
+         context: "Need a decision",
+         allowMultiple: false,
+         allowFreeform: true,
+         allowComment: true,
+      });
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"], comment: "safer" })).toBe(true);
+
+      const result = await pending;
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["B"], comment: "safer" });
+      expect(result.content[0].text).toBe("User answered: B — safer");
+      const answeredEvent = emittedEvents.find((event) => event.name === "ask:answered");
+      expect(answeredEvent?.payload.toolCallId).toBe("tool-call-id");
+      expect(answeredEvent?.payload.response).toEqual({ kind: "selection", selections: ["B"], comment: "safer" });
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["A"] })).toBe(false);
+   });
+
+   test("external responder can win the RPC dialog fallback race", async () => {
+      const tool = await setupTool();
+
+      const pending = tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick a color",
+            options: ["Red", "Blue"],
+            allowFreeform: false,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async () => undefined,
+               select: async () => new Promise(() => undefined),
+               input: async () => undefined,
+            },
+         },
+      );
+
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["Blue"] })).toBe(true);
+
+      const result = await pending;
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["Blue"] });
+   });
+
+   test("external responder returns false after the local UI already answered", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["A", "B"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => new Promise((resolve) => {
+                  const component = factory(
+                     { terminal: { rows: 30 }, requestRender: () => undefined },
+                     createTheme(),
+                     createKeybindings(),
+                     resolve,
+                  );
+                  component.handleInput("enter");
+               }),
+               onTerminalInput: () => () => undefined,
+               notify: () => undefined,
+            },
+         },
+      );
+
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["A"] });
+      const promptEvent = emittedEvents.find((event) => event.name === "ask:prompt");
+      expect(promptEvent?.payload.respond({ kind: "selection", selections: ["B"] })).toBe(false);
+   });
+
    test("uses non-overlay custom UI when displayMode is inline", async () => {
       const tool = await setupTool();
       let capturedOptions: any;

--- a/index.ts
+++ b/index.ts
@@ -140,6 +140,7 @@ type ExternalAskWaitResult =
 type ExternalAskBridge = {
    bindDone(done: (result: AskUIResult | null) => void): void;
    settleFromLocal(): void;
+   getExternalResult(): Extract<ExternalAskWaitResult, { source: "external" }> | undefined;
    wait(): Promise<ExternalAskWaitResult>;
 };
 
@@ -185,6 +186,9 @@ function createExternalAskBridge(
          settled = true;
          doneCallback = undefined;
          resolveExternal({ source: "settled" });
+      },
+      getExternalResult() {
+         return settledByExternal ? { source: "external", result: externalResult ?? null } : undefined;
       },
       wait() {
          return externalPromise;
@@ -248,6 +252,7 @@ function normalizeExternalAskResult(
       if (typeof response.text !== "string") return undefined;
       const normalized = createFreeformResponse(response.text);
       if (!normalized) return undefined;
+      if (prompt.allowComment && response.comment != null && typeof response.comment !== "string") return undefined;
       const comment = prompt.allowComment ? normalizeOptionalComment(response.comment) : undefined;
       return comment ? { ...normalized, comment } : normalized;
    }
@@ -265,6 +270,7 @@ function normalizeExternalAskResult(
       if (optionTitles.size === 0) return undefined;
       if (normalizedSelections.some((selection) => !optionTitles.has(selection))) return undefined;
 
+      if (prompt.allowComment && response.comment != null && typeof response.comment !== "string") return undefined;
       return createSelectionResponse(
          normalizedSelections,
          prompt.allowComment ? response.comment : undefined,
@@ -1532,7 +1538,41 @@ class AskComponent extends Container {
 /**
  * RPC/headless fallback: use dialog methods (select/input) instead of the rich TUI overlay.
  * ctx.ui.custom() returns undefined in RPC mode, so we degrade gracefully.
+ * When available, pass the agent abort signal through so host dialogs can cancel too.
  */
+function createDialogAbortController(parentSignal?: AbortSignal): {
+   signal?: AbortSignal;
+   abort: () => void;
+   cleanup: () => void;
+} {
+   if (typeof AbortController !== "function") {
+      return { signal: parentSignal, abort: () => { }, cleanup: () => { } };
+   }
+
+   const controller = new AbortController();
+   let removeParentAbortListener: (() => void) | undefined;
+   if (parentSignal) {
+      if (parentSignal.aborted) {
+         controller.abort(parentSignal.reason);
+      } else {
+         const onAbort = () => controller.abort(parentSignal.reason);
+         parentSignal.addEventListener("abort", onAbort, { once: true });
+         removeParentAbortListener = () => parentSignal.removeEventListener("abort", onAbort);
+      }
+   }
+
+   return {
+      signal: controller.signal,
+      abort: () => {
+         if (!controller.signal.aborted) controller.abort();
+      },
+      cleanup: () => {
+         removeParentAbortListener?.();
+         removeParentAbortListener = undefined;
+      },
+   };
+}
+
 async function askViaDialogs(
    ui: { select: Function; input: Function },
    question: string,
@@ -1542,9 +1582,13 @@ async function askViaDialogs(
    allowFreeform: boolean,
    allowComment: boolean,
    timeout?: number,
+   signal?: AbortSignal,
 ): Promise<AskUIResult | null> {
-   const dialogOpts = timeout ? { timeout } : undefined;
+   const dialogOpts = timeout || signal
+      ? { ...(timeout ? { timeout } : {}), ...(signal ? { signal } : {}) }
+      : undefined;
    const prompt = context ? `${question}\n\nContext:\n${context}` : question;
+   if (signal?.aborted) return null;
 
    if (options.length === 0) {
       const answer = await ui.input(prompt, "Type your answer...", dialogOpts) as string | undefined;
@@ -1766,13 +1810,13 @@ export default function(pi: ExtensionAPI) {
                const doneOnce = (value: AskUIResult | null) => finish(value, "local");
                externalBridge.bindDone((value) => finish(value, "external"));
 
-               if (signal) {
+               if (!completed && signal) {
                   const onAbort = () => doneOnce(null);
                   signal.addEventListener("abort", onAbort, { once: true });
                   removeAbortListener = () => signal.removeEventListener("abort", onAbort);
                }
 
-               if (timeout && timeout > 0) {
+               if (!completed && timeout && timeout > 0) {
                   timeoutHandle = setTimeout(() => doneOnce(null), timeout);
                }
 
@@ -1828,11 +1872,18 @@ export default function(pi: ExtensionAPI) {
                // RPC/headless mode: degrade to select()/input() dialog protocol.
                // Race the dialogs with the external responder so a mirrored UI can
                // answer first even when rich custom UI is unavailable.
-               const raceResult = await Promise.race([
-                  askViaDialogs(ctx.ui, question, normalizedContext, options, allowMultiple, allowFreeform, allowComment, timeout)
-                     .then((dialogResult) => ({ source: "local" as const, result: dialogResult })),
-                  externalBridge.wait(),
-               ]);
+               const alreadyExternal = externalBridge.getExternalResult();
+               const raceResult = alreadyExternal ?? await (async () => {
+                  const dialogAbort = createDialogAbortController(signal);
+                  return Promise.race([
+                     askViaDialogs(ctx.ui, question, normalizedContext, options, allowMultiple, allowFreeform, allowComment, timeout, dialogAbort.signal)
+                        .then((dialogResult) => ({ source: "local" as const, result: dialogResult })),
+                     externalBridge.wait().then((externalResult) => {
+                        if (externalResult.source === "external") dialogAbort.abort();
+                        return externalResult;
+                     }),
+                  ]).finally(() => dialogAbort.cleanup());
+               })();
                if (raceResult.source === "local") {
                   externalBridge.settleFromLocal();
                   result = raceResult.result;

--- a/index.ts
+++ b/index.ts
@@ -108,6 +108,7 @@ type AskResponse =
    | {
       kind: "freeform";
       text: string;
+      comment?: string;
    };
 
 interface AskToolDetails {
@@ -119,6 +120,61 @@ interface AskToolDetails {
 }
 
 type AskUIResult = AskResponse;
+
+type ExternalAskPromptEvent = {
+   toolCallId: string;
+   question: string;
+   context?: string;
+   options: QuestionOption[];
+   allowMultiple: boolean;
+   allowFreeform: boolean;
+   allowComment: boolean;
+   respond: (result: AskUIResult | null) => boolean;
+   resolve: (result: AskUIResult | null) => boolean;
+};
+
+type ExternalAskBridge = {
+   bindDone(done: (result: AskUIResult | null) => void): void;
+   settleFromLocal(): void;
+   wait(): Promise<AskUIResult | null>;
+};
+
+function createExternalAskBridge(
+   pi: ExtensionAPI,
+   event: Omit<ExternalAskPromptEvent, "respond" | "resolve">,
+): ExternalAskBridge {
+   let settled = false;
+   let externalResult: AskUIResult | null | undefined;
+   let doneCallback: ((result: AskUIResult | null) => void) | undefined;
+   let resolveExternal: (result: AskUIResult | null) => void = () => { };
+   const externalPromise = new Promise<AskUIResult | null>((resolve) => {
+      resolveExternal = resolve;
+   });
+
+   const respond = (result: AskUIResult | null): boolean => {
+      if (settled) return false;
+      settled = true;
+      externalResult = result;
+      doneCallback?.(result);
+      resolveExternal(result);
+      return true;
+   };
+
+   pi.events.emit("ask:prompt", { ...event, respond, resolve: respond } satisfies ExternalAskPromptEvent);
+
+   return {
+      bindDone(done) {
+         doneCallback = done;
+         if (settled) done(externalResult ?? null);
+      },
+      settleFromLocal() {
+         settled = true;
+      },
+      wait() {
+         return externalPromise;
+      },
+   };
+}
 
 function normalizeOptions(options: AskOptionInput[]): QuestionOption[] {
    return options
@@ -164,7 +220,9 @@ function createSelectionResponse(selections: string[], comment?: string | null):
 }
 
 function formatResponseSummary(response: AskResponse): string {
-   if (response.kind === "freeform") return response.text;
+   if (response.kind === "freeform") {
+      return response.comment ? `${response.text} — ${response.comment}` : response.text;
+   }
 
    const selections = response.selections.join(", ");
    return response.comment ? `${selections} — ${response.comment}` : selections;
@@ -1095,7 +1153,11 @@ class AskComponent extends Container {
       ));
 
       this.updateStaticText();
-      this.showSelectMode();
+      if (this.options.length === 0) {
+         this.showFreeformMode();
+      } else {
+         this.showSelectMode();
+      }
    }
 
    override invalidate(): void {
@@ -1383,7 +1445,11 @@ class AskComponent extends Container {
    handleInput(data: string): void {
       if (this.mode === "freeform" || this.mode === "comment") {
          if (matchesKey(data, Key.escape)) {
-            this.showSelectMode();
+            if (this.options.length === 0) {
+               this.onDone(null);
+            } else {
+               this.showSelectMode();
+            }
             return;
          }
 
@@ -1599,24 +1665,15 @@ export default function(pi: ExtensionAPI) {
             };
          }
 
-         if (options.length === 0) {
-            const prompt = normalizedContext ? `${question}\n\nContext:\n${normalizedContext}` : question;
-            const answer = await ctx.ui.input(prompt, "Type your answer...", timeout ? { timeout } : undefined);
-            const response = createFreeformResponse(answer);
-
-            if (!response) {
-               return {
-                  content: [{ type: "text", text: "User cancelled the question" }],
-                  details: { question, context: normalizedContext, options, response: null, cancelled: true } as AskToolDetails,
-               };
-            }
-
-            pi.events.emit("ask:answered", { question, context: normalizedContext, response });
-            return {
-               content: [{ type: "text", text: `User answered: ${formatResponseSummary(response)}` }],
-               details: { question, context: normalizedContext, options, response, cancelled: false } as AskToolDetails,
-            };
-         }
+         const externalBridge = createExternalAskBridge(pi, {
+            toolCallId: _toolCallId,
+            question,
+            context: normalizedContext,
+            options,
+            allowMultiple,
+            allowFreeform,
+            allowComment,
+         });
 
          onUpdate?.({
             content: [{ type: "text", text: "Waiting for user input..." }],
@@ -1629,13 +1686,23 @@ export default function(pi: ExtensionAPI) {
          let hasAnnouncedHide = false;
          try {
             const customFactory = (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: AskUIResult | null) => void) => {
+               let completed = false;
+               const finish = (value: AskUIResult | null, source: "local" | "external") => {
+                  if (completed) return;
+                  completed = true;
+                  if (source === "local") externalBridge.settleFromLocal();
+                  done(value);
+               };
+               const doneOnce = (value: AskUIResult | null) => finish(value, "local");
+               externalBridge.bindDone((value) => finish(value, "external"));
+
                if (signal) {
-                  const onAbort = () => done(null);
+                  const onAbort = () => doneOnce(null);
                   signal.addEventListener("abort", onAbort, { once: true });
                }
 
                if (timeout && timeout > 0) {
-                  setTimeout(() => done(null), timeout);
+                  setTimeout(() => doneOnce(null), timeout);
                }
 
                return new AskComponent(
@@ -1650,7 +1717,7 @@ export default function(pi: ExtensionAPI) {
                   theme,
                   keybindings,
                   shortcuts,
-                  done,
+                  doneOnce,
                );
             };
 
@@ -1686,8 +1753,17 @@ export default function(pi: ExtensionAPI) {
             if (customResult !== undefined) {
                result = customResult;
             } else {
-               // RPC/headless mode: degrade to select()/input() dialog protocol
-               result = await askViaDialogs(ctx.ui, question, normalizedContext, options, allowMultiple, allowFreeform, allowComment, timeout);
+               // RPC/headless mode: degrade to select()/input() dialog protocol.
+               // Race the dialogs with the external responder so Android can still
+               // answer first even when rich custom UI is unavailable.
+               result = await Promise.race([
+                  askViaDialogs(ctx.ui, question, normalizedContext, options, allowMultiple, allowFreeform, allowComment, timeout)
+                     .then((dialogResult) => {
+                        externalBridge.settleFromLocal();
+                        return dialogResult;
+                     }),
+                  externalBridge.wait(),
+               ]);
             }
          } catch (error) {
             const message =
@@ -1702,7 +1778,7 @@ export default function(pi: ExtensionAPI) {
          }
 
          if (result === null) {
-            pi.events.emit("ask:cancelled", { question, context: normalizedContext, options });
+            pi.events.emit("ask:cancelled", { toolCallId: _toolCallId, question, context: normalizedContext, options });
             return {
                content: [{ type: "text", text: "User cancelled the question" }],
                details: { question, context: normalizedContext, options, response: null, cancelled: true } as AskToolDetails,
@@ -1710,6 +1786,7 @@ export default function(pi: ExtensionAPI) {
          }
 
          pi.events.emit("ask:answered", {
+            toolCallId: _toolCallId,
             question,
             context: normalizedContext,
             response: result,

--- a/index.ts
+++ b/index.ts
@@ -133,10 +133,14 @@ type ExternalAskPromptEvent = {
    resolve: (result: AskUIResult | null) => boolean;
 };
 
+type ExternalAskWaitResult =
+   | { source: "external"; result: AskUIResult | null }
+   | { source: "settled" };
+
 type ExternalAskBridge = {
    bindDone(done: (result: AskUIResult | null) => void): void;
    settleFromLocal(): void;
-   wait(): Promise<AskUIResult | null>;
+   wait(): Promise<ExternalAskWaitResult>;
 };
 
 function createExternalAskBridge(
@@ -144,19 +148,25 @@ function createExternalAskBridge(
    event: Omit<ExternalAskPromptEvent, "respond" | "resolve">,
 ): ExternalAskBridge {
    let settled = false;
+   let settledByExternal = false;
    let externalResult: AskUIResult | null | undefined;
    let doneCallback: ((result: AskUIResult | null) => void) | undefined;
-   let resolveExternal: (result: AskUIResult | null) => void = () => { };
-   const externalPromise = new Promise<AskUIResult | null>((resolve) => {
+   let resolveExternal: (result: ExternalAskWaitResult) => void = () => { };
+   const externalPromise = new Promise<ExternalAskWaitResult>((resolve) => {
       resolveExternal = resolve;
    });
 
-   const respond = (result: AskUIResult | null): boolean => {
+   const respond = (rawResult: AskUIResult | null): boolean => {
       if (settled) return false;
+      const result = normalizeExternalAskResult(rawResult, event);
+      if (result === undefined) return false;
       settled = true;
+      settledByExternal = true;
       externalResult = result;
-      doneCallback?.(result);
-      resolveExternal(result);
+      const done = doneCallback;
+      doneCallback = undefined;
+      done?.(result);
+      resolveExternal({ source: "external", result });
       return true;
    };
 
@@ -164,11 +174,17 @@ function createExternalAskBridge(
 
    return {
       bindDone(done) {
-         doneCallback = done;
-         if (settled) done(externalResult ?? null);
+         if (settledByExternal) {
+            done(externalResult ?? null);
+            return;
+         }
+         if (!settled) doneCallback = done;
       },
       settleFromLocal() {
+         if (settled) return;
          settled = true;
+         doneCallback = undefined;
+         resolveExternal({ source: "settled" });
       },
       wait() {
          return externalPromise;
@@ -217,6 +233,45 @@ function createSelectionResponse(selections: string[], comment?: string | null):
    return normalizedComment
       ? { kind: "selection", selections: normalizedSelections, comment: normalizedComment }
       : { kind: "selection", selections: normalizedSelections };
+}
+
+function normalizeExternalAskResult(
+   result: unknown,
+   prompt: Omit<ExternalAskPromptEvent, "respond" | "resolve">,
+): AskUIResult | null | undefined {
+   if (result === null) return null;
+   if (!result || typeof result !== "object") return undefined;
+
+   const response = result as Partial<AskResponse>;
+   if (response.kind === "freeform") {
+      if (!prompt.allowFreeform && prompt.options.length > 0) return undefined;
+      if (typeof response.text !== "string") return undefined;
+      const normalized = createFreeformResponse(response.text);
+      if (!normalized) return undefined;
+      const comment = prompt.allowComment ? normalizeOptionalComment(response.comment) : undefined;
+      return comment ? { ...normalized, comment } : normalized;
+   }
+
+   if (response.kind === "selection") {
+      if (!Array.isArray(response.selections)) return undefined;
+      const normalizedSelections = response.selections
+         .filter((selection): selection is string => typeof selection === "string")
+         .map((selection) => selection.trim())
+         .filter(Boolean);
+      if (normalizedSelections.length === 0) return undefined;
+      if (!prompt.allowMultiple && normalizedSelections.length > 1) return undefined;
+
+      const optionTitles = new Set(prompt.options.map((option) => option.title));
+      if (optionTitles.size === 0) return undefined;
+      if (normalizedSelections.some((selection) => !optionTitles.has(selection))) return undefined;
+
+      return createSelectionResponse(
+         normalizedSelections,
+         prompt.allowComment ? response.comment : undefined,
+      ) ?? undefined;
+   }
+
+   return undefined;
 }
 
 function formatResponseSummary(response: AskResponse): string {
@@ -1491,6 +1546,12 @@ async function askViaDialogs(
    const dialogOpts = timeout ? { timeout } : undefined;
    const prompt = context ? `${question}\n\nContext:\n${context}` : question;
 
+   if (options.length === 0) {
+      const answer = await ui.input(prompt, "Type your answer...", dialogOpts) as string | undefined;
+      if (isCancelledInput(answer)) return null;
+      return createFreeformResponse(answer);
+   }
+
    if (allowMultiple) {
       const optionList = formatOptionsForMessage(options);
       const rawSelections = await ui.input(
@@ -1687,9 +1748,18 @@ export default function(pi: ExtensionAPI) {
          try {
             const customFactory = (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: AskUIResult | null) => void) => {
                let completed = false;
+               let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+               let removeAbortListener: (() => void) | undefined;
+               const cleanup = () => {
+                  if (timeoutHandle) clearTimeout(timeoutHandle);
+                  timeoutHandle = undefined;
+                  removeAbortListener?.();
+                  removeAbortListener = undefined;
+               };
                const finish = (value: AskUIResult | null, source: "local" | "external") => {
                   if (completed) return;
                   completed = true;
+                  cleanup();
                   if (source === "local") externalBridge.settleFromLocal();
                   done(value);
                };
@@ -1699,10 +1769,11 @@ export default function(pi: ExtensionAPI) {
                if (signal) {
                   const onAbort = () => doneOnce(null);
                   signal.addEventListener("abort", onAbort, { once: true });
+                  removeAbortListener = () => signal.removeEventListener("abort", onAbort);
                }
 
                if (timeout && timeout > 0) {
-                  setTimeout(() => doneOnce(null), timeout);
+                  timeoutHandle = setTimeout(() => doneOnce(null), timeout);
                }
 
                return new AskComponent(
@@ -1751,21 +1822,29 @@ export default function(pi: ExtensionAPI) {
             );
 
             if (customResult !== undefined) {
+               externalBridge.settleFromLocal();
                result = customResult;
             } else {
                // RPC/headless mode: degrade to select()/input() dialog protocol.
-               // Race the dialogs with the external responder so Android can still
+               // Race the dialogs with the external responder so a mirrored UI can
                // answer first even when rich custom UI is unavailable.
-               result = await Promise.race([
+               const raceResult = await Promise.race([
                   askViaDialogs(ctx.ui, question, normalizedContext, options, allowMultiple, allowFreeform, allowComment, timeout)
-                     .then((dialogResult) => {
-                        externalBridge.settleFromLocal();
-                        return dialogResult;
-                     }),
+                     .then((dialogResult) => ({ source: "local" as const, result: dialogResult })),
                   externalBridge.wait(),
                ]);
+               if (raceResult.source === "local") {
+                  externalBridge.settleFromLocal();
+                  result = raceResult.result;
+               } else if (raceResult.source === "external") {
+                  result = raceResult.result;
+               } else {
+                  result = null;
+               }
             }
          } catch (error) {
+            externalBridge.settleFromLocal();
+            pi.events.emit("ask:cancelled", { toolCallId: _toolCallId, question, context: normalizedContext, options });
             const message =
                error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error);
             return {


### PR DESCRIPTION
## Summary

- Emit a normalized `ask:prompt` event when `ask_user` opens, with an in-process `respond(result | null)` callback for external UIs.
- Race the local TUI/RPC prompt with the external responder so the first answer wins and the tool still returns the normal `ask_user` result shape.
- Emit `ask:answered` / `ask:cancelled` after settlement so mirrored prompt cards can close or mark themselves resolved.
- Harden settlement paths after review: direct `custom()` returns now settle the bridge, empty-option RPC fallback uses direct input again, external responses are normalized/validated, and timeout/abort cleanup is explicit.
- Document the event contract and RPC-dialog cancellation limitation in the README.

## Motivation

This is intended for same-process integrations that mirror `ask_user` prompts outside the local terminal (mobile app, chat bridge, web UI, etc.) while preserving the existing local TUI. Normal CLI/TUI usage remains unchanged.

## Test plan

- `bun test index.test.ts single-select-layout.test.ts` → 66 pass / 0 fail
- `npm run check` → `npm pack --dry-run` succeeds
