### PR TITLE
Fix ask_user options in cmux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.12.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.12.0) - 2026-07-06
+
+### Fixed
+
+- `ask_user` failing under schema-mangling hosts/proxies (cmux, Google function calling, Codex-style backends) that strip or reject the `anyOf` union in the `options` items schema. Models behind such proxies could not see the option shape, guessed keys like `{ "text": … }` or sent empty objects, and every option was silently dropped — the tool then fell into an empty freeform prompt that ended in `Cancelled`. Closes #22. Three changes:
+  - The `options` schema is now a flat `{ title, description? }` object array with no `anyOf`, so every provider sees a concrete shape. Plain strings remain accepted at runtime.
+  - Option normalization now salvages common alias keys (`label`, `text`, `value`, `name`, `option`) and coerces primitive entries, instead of dropping anything without a `title`.
+  - When every option is malformed, the tool returns an error result telling the model the expected shape so it can retry, instead of silently showing a freeform prompt.
+
 ## [0.11.2](https://github.com/edlsh/pi-ask-user/releases/tag/v0.11.2) - 2026-06-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The registered tool name is:
 |-----------|------|---------|-------------|
 | `question` | `string` | *required* | The question to ask the user |
 | `context` | `string?` | — | Relevant context summary shown before the question |
-| `options` | `(string \| {title, description?})[]?` | `[]` | Multiple-choice options |
+| `options` | `{title, description?}[]?` | `[]` | Multiple-choice options. The schema is a flat object shape (no `anyOf`, which some provider proxies strip or reject); plain strings and common alias keys (`label`, `text`, `value`, `name`, `option`) are still accepted at runtime |
 | `allowMultiple` | `boolean?` | `false` | Enable multi-select mode |
 | `allowFreeform` | `boolean?` | `true` | Add a "Type something" freeform option |
 | `allowComment` | `boolean?` | `false` | Expose a user-toggleable extra-context option in the custom UI (`ctrl+g` or the toggle row) and collect an optional comment in fallback dialogs |
@@ -77,7 +77,7 @@ The registered tool name is:
   "question": "Which option should we use?",
   "context": "We are choosing a deploy target.",
   "options": [
-    "staging",
+    { "title": "staging" },
     { "title": "production", "description": "Customer-facing" }
   ],
   "allowMultiple": false,

--- a/index.test.ts
+++ b/index.test.ts
@@ -2015,6 +2015,145 @@ describe("ask_user", () => {
    });
 
 
+
+   describe("issue #22 option normalization", () => {
+      test("salvages common option title aliases when schema proxies mangle the shape", async () => {
+         const tool = await setupTool();
+         let selectOptions: string[] = [];
+
+         const result = await tool.execute(
+            "tool-call-id",
+            {
+               question: "Pick one",
+               options: [
+                  { label: "A" },
+                  { text: "B" },
+                  { value: "C" },
+                  { name: "D" },
+                  { option: "E" },
+               ],
+               allowFreeform: false,
+            },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async () => undefined,
+                  select: async (_title: string, opts: string[]) => {
+                     selectOptions = opts;
+                     return "C";
+                  },
+                  input: async () => undefined,
+               },
+            },
+         );
+
+         expect(selectOptions).toEqual(["A", "B", "C", "D", "E"]);
+         expect(result.details.response).toEqual({ kind: "selection", selections: ["C"] });
+         expect(result.details.options.map((option: { title: string }) => option.title)).toEqual(["A", "B", "C", "D", "E"]);
+      });
+
+      test("filters blank labels, coerces primitive options, and keeps only non-blank descriptions", async () => {
+         const tool = await setupTool();
+         let selectOptions: string[] = [];
+
+         const result = await tool.execute(
+            "tool-call-id",
+            {
+               question: "Pick one",
+               options: [
+                  "  ",
+                  "",
+                  42,
+                  true,
+                  "Real",
+                  { title: "A", description: "  " },
+                  { label: "B", description: "why" },
+               ],
+               allowFreeform: false,
+            },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async () => undefined,
+                  select: async (_title: string, opts: string[]) => {
+                     selectOptions = opts;
+                     return "B";
+                  },
+                  input: async () => undefined,
+               },
+            },
+         );
+
+         expect(selectOptions).toEqual(["42", "true", "Real", "A", "B"]);
+         expect(result.details.options).toEqual([
+            { title: "42" },
+            { title: "true" },
+            { title: "Real" },
+            { title: "A" },
+            { title: "B", description: "why" },
+         ]);
+      });
+
+      test("returns an error instead of opening UI when every supplied option is malformed", async () => {
+         const tool = await setupTool();
+         let calls = 0;
+
+         const result = await tool.execute(
+            "tool-call-id",
+            {
+               question: "Pick one",
+               options: [{}, { foo: "x" }, "   "],
+            },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async () => {
+                     calls += 1;
+                     return undefined;
+                  },
+                  select: async () => {
+                     calls += 1;
+                     return undefined;
+                  },
+                  input: async () => {
+                     calls += 1;
+                     return undefined;
+                  },
+               },
+            },
+         );
+
+         const text = result.content.map((part: { text?: string }) => part.text ?? "").join("\n");
+         expect(result.isError).toBe(true);
+         expect(text).toContain("option(s) were malformed");
+         expect(text).toContain("{ \"title\": \"Short label\", \"description\": \"Optional detail\" }");
+         expect(result.details.error).toBe("Malformed options: no entry had a usable title");
+         expect(calls).toBe(0);
+      });
+
+      test("keeps the registered options schema flat without union combinators", async () => {
+         const source = await Bun.file("index.ts").text();
+         const start = source.indexOf("options: Type.Optional(");
+         const end = source.indexOf("allowMultiple: Type.Optional(", start);
+         const optionSchema = source.slice(start, end);
+
+         expect(start).toBeGreaterThanOrEqual(0);
+         expect(end).toBeGreaterThan(start);
+         expect(optionSchema).toContain("Type.Array(");
+         expect(optionSchema).toContain("Type.Object({");
+         expect(optionSchema).toContain("title: Type.String");
+         expect(optionSchema).not.toContain("Type.Union");
+         expect(optionSchema).not.toContain("anyOf");
+         expect(optionSchema).not.toContain("oneOf");
+      });
+   });
+
    describe("RPC fallback (custom() returns undefined)", () => {
       test("single-select falls back to ctx.ui.select()", async () => {
          const tool = await setupTool();

--- a/index.ts
+++ b/index.ts
@@ -23,13 +23,14 @@ import {
    type MarkdownTheme,
    matchesKey,
    type OverlayHandle,
+   type OverlayOptions,
    Spacer,
    Text,
    type TUI,
    truncateToWidth,
    wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { renderSingleSelectRows } from "./single-select-layout";
+import { renderSingleSelectRows, type QuestionOption } from "./single-select-layout";
 
 import { createRequire } from "node:module";
 const _require = createRequire(import.meta.url);
@@ -121,18 +122,28 @@ interface AskToolDetails {
 
 type AskUIResult = AskResponse;
 
-function normalizeOptions(options: AskOptionInput[]): QuestionOption[] {
-   return options
-      .map((option) => {
-         if (typeof option === "string") {
-            return { title: option };
+// Key aliases models fall back to when a schema-mangling proxy (Google
+// function calling, Codex-style backends, cmux) strips the option shape and
+// the model has to guess. See issue #22.
+const OPTION_TITLE_KEYS = ["title", "label", "text", "value", "name", "option"] as const;
+
+function coerceOption(option: unknown): QuestionOption | null {
+   if (typeof option === "string" || typeof option === "number" || typeof option === "boolean") {
+      const title = String(option).trim();
+      return title ? { title } : null;
+   }
+   if (option && typeof option === "object") {
+      const record = option as Record<string, unknown>;
+      for (const key of OPTION_TITLE_KEYS) {
+         const value = record[key];
+         if (typeof value === "string" && value.trim()) {
+            const description =
+               typeof record.description === "string" && record.description.trim() ? record.description : undefined;
+            return description ? { title: value.trim(), description } : { title: value.trim() };
          }
-         if (option && typeof option === "object" && typeof option.title === "string") {
-            return { title: option.title, description: option.description };
-         }
-         return null;
-      })
-      .filter((option): option is QuestionOption => option !== null);
+      }
+   }
+   return null;
 }
 
 function formatOptionsForMessage(options: QuestionOption[]): string {
@@ -390,7 +401,7 @@ function matchesSelectDown(data: string, keybindings: KeybindingsManager): boole
 function buildCustomUIOptions(
    displayMode: AskDisplayMode,
    onHandle?: (handle: OverlayHandle) => void,
-) {
+): { overlay?: boolean; overlayOptions?: OverlayOptions; onHandle?: (handle: OverlayHandle) => void } | undefined {
    switch (displayMode) {
       case "inline":
          return undefined;
@@ -1817,15 +1828,17 @@ export default function(pi: ExtensionAPI) {
          ),
          options: Type.Optional(
             Type.Array(
-               Type.Union([
-                  Type.String({ description: "Short title for this option" }),
-                  Type.Object({
-                     title: Type.String({ description: "Short title for this option" }),
-                     description: Type.Optional(
-                        Type.String({ description: "Longer description explaining this option" }),
-                     ),
-                  }),
-               ]),
+               // Flat object shape: union item schemas get stripped or rejected
+               // by several providers/proxies (Google function calling,
+               // Codex-style backends, cmux), leaving the model to guess the shape
+               // and produce empty options. Plain strings are still accepted at
+               // runtime for older transcripts. See issue #22.
+               Type.Object({
+                  title: Type.String({ description: "Short title for this option" }),
+                  description: Type.Optional(
+                     Type.String({ description: "Longer description explaining this option" }),
+                  ),
+               }),
                { description: "List of options for the user to choose from" },
             ),
          ),
@@ -1896,8 +1909,24 @@ export default function(pi: ExtensionAPI) {
                DEFAULT_COMMENT_TOGGLE_KEY,
             ),
          };
-         const options = normalizeOptions(rawOptions);
+         const options = rawOptions.map(coerceOption).filter((option): option is QuestionOption => option !== null);
          const normalizedContext = context?.trim() || undefined;
+
+         if (rawOptions.length > 0 && options.length === 0) {
+            return {
+               content: [
+                  {
+                     type: "text",
+                     text:
+                        `All ${rawOptions.length} option(s) were malformed, so nothing could be shown to the user. `
+                        + `Each option must be a plain string or an object like { "title": "Short label", "description": "Optional detail" }. `
+                        + `Call ask_user again with corrected options.`,
+                  },
+               ],
+               isError: true,
+               details: { error: "Malformed options: no entry had a usable title" },
+            };
+         }
 
          if (!ctx.hasUI || !ctx.ui) {
             const optionText = options.length > 0 ? `\n\nOptions:\n${formatOptionsForMessage(options)}` : "";
@@ -2049,9 +2078,7 @@ export default function(pi: ExtensionAPI) {
          let text = theme.fg("toolTitle", theme.bold("ask_user "));
          text += theme.fg("muted", question);
          if (rawOptions.length > 0) {
-            const labels = rawOptions.map((o: unknown) =>
-               typeof o === "string" ? o : (o as QuestionOption)?.title ?? "",
-            );
+            const labels = rawOptions.map((o: unknown) => coerceOption(o)?.title ?? "<invalid>");
             text += "\n" + theme.fg("dim", `  ${rawOptions.length} option(s): ${labels.join(", ")}`);
          }
          if (args.allowMultiple) {
@@ -2072,8 +2099,7 @@ export default function(pi: ExtensionAPI) {
 
          if (options.isPartial) {
             const waitingText = result.content
-               ?.filter((part: { type?: string; text?: string }) => part?.type === "text")
-               .map((part: { text?: string }) => part.text ?? "")
+               ?.map((part) => part.type === "text" ? part.text : "")
                .join("\n")
                .trim() || "Waiting for user input...";
             return new Text(theme.fg("muted", waitingText), 0, 0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-ask-user",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Interactive ask_user tool for pi-coding-agent with searchable split-pane selection UI, multi-select, and freeform input",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- Flatten `ask_user` option item schema to `{ title, description? }` so providers/proxies do not strip union schemas
- Salvage common model-guessed option keys (`label`, `text`, `value`, `name`, `option`) while keeping plain-string runtime compatibility
- Return a clear error when every supplied option is malformed instead of silently falling into a cancelled freeform prompt
- Add issue #22 regressions and update docs/changelog for v0.12.0

Closes #22

## Verification

- `bun test index.test.ts -t 'issue #22'`
- `bun test`
- `bunx tsc --noEmit --strict --skipLibCheck --module esnext --moduleResolution bundler --target es2022 index.ts`
- `npm pack --dry-run`