### PR TITLE
Emit lifecycle events while awaiting user input

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -247,6 +247,43 @@ describe("ask_user", () => {
       expect((tool as any).executionMode).toBe("sequential");
    });
 
+   test("emits Herdr blocked lifecycle while awaiting a structured answer", async () => {
+      const tool = await setupTool();
+
+      await tool.execute(
+         "tool-call-id",
+         { question: "Continue?", options: ["Yes"] },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: { custom: async () => ({ kind: "selection", selections: ["Yes"] }) },
+         },
+      );
+
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
+   test("emits Herdr blocked lifecycle while awaiting a freeform answer", async () => {
+      const tool = await setupTool();
+
+      await tool.execute(
+         "tool-call-id",
+         { question: "Why?", options: [] },
+         undefined,
+         undefined,
+         { hasUI: true, ui: { input: async () => "Because" } },
+      );
+
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
    test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;

--- a/index.test.ts
+++ b/index.test.ts
@@ -284,6 +284,42 @@ describe("ask_user", () => {
       ]);
    });
 
+   test("clears Herdr blocked lifecycle when structured UI rejects", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         { question: "Continue?", options: ["Yes"] },
+         undefined,
+         undefined,
+         { hasUI: true, ui: { custom: async () => { throw new Error("UI failed"); } } },
+      );
+
+      expect(result.isError).toBe(true);
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
+   test("clears Herdr blocked lifecycle when freeform input is cancelled", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         { question: "Why?", options: [] },
+         undefined,
+         undefined,
+         { hasUI: true, ui: { input: async () => undefined } },
+      );
+
+      expect(result.details.cancelled).toBe(true);
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
    test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;

--- a/index.ts
+++ b/index.ts
@@ -1947,7 +1947,13 @@ export default function(pi: ExtensionAPI) {
 
          if (options.length === 0) {
             const prompt = normalizedContext ? `${question}\n\nContext:\n${normalizedContext}` : question;
-            const answer = await ctx.ui.input(prompt, "Type your answer...", timeout ? { timeout } : undefined);
+            pi.events.emit("herdr:blocked", { active: true, label: "Waiting for user response" });
+            let answer: string | undefined;
+            try {
+               answer = await ctx.ui.input(prompt, "Type your answer...", timeout ? { timeout } : undefined);
+            } finally {
+               pi.events.emit("herdr:blocked", { active: false });
+            }
             const response = createFreeformResponse(answer);
 
             if (!response) {
@@ -1973,6 +1979,7 @@ export default function(pi: ExtensionAPI) {
          let overlayHandle: OverlayHandle | undefined;
          let removeOverlayInputListener: (() => void) | undefined;
          let hasAnnouncedHide = false;
+         pi.events.emit("herdr:blocked", { active: true, label: "Waiting for user response" });
          try {
             const customFactory = (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: AskUIResult | null) => void) => {
                if (signal) {
@@ -2045,6 +2052,7 @@ export default function(pi: ExtensionAPI) {
             };
          } finally {
             removeOverlayInputListener?.();
+            pi.events.emit("herdr:blocked", { active: false });
          }
 
          if (result === null) {


### PR DESCRIPTION
## Summary
- emit `herdr:blocked` while `ask_user` awaits structured or freeform input
- clear event in `finally`, including cancellation and errors
- cover both interaction paths with regression tests

`herdr:blocked` is a no-op for installations without a listener. Herdr\u2019s Pi integration already listens for this event and reports `blocked` rather than `working` while an interactive prompt is open.

## Test
- `bun test`