### PR TITLE
v0.13.0: PI_ASK_USER_ALLOW_COMMENT preference, env diagnostics, known-limitation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.13.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.0) - 2026-07-12
+
+### Added
+
+- `PI_ASK_USER_ALLOW_COMMENT` preference for globally enabling optional comments while preserving per-call precedence and the existing `false` default. Closes #26.
+
+### Changed
+
+- Display mode environment values now tolerate surrounding whitespace and capitalization, and the documentation clarifies that Pi must inherit `PI_ASK_USER_*` variables from its launching process. Diagnostic hardening related to #24; the reported reproduction (a valid lowercase `inline`) is not resolved by this entry.
+- Documented that pi-tui's overlay compositor skips image rows, leaving overlay prompts invisible where inline images are on screen, with `displayMode: "inline"` as the workaround. Root cause is upstream in pi-tui; related to #8.
+
 ## [0.12.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.12.0) - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The registered tool name is:
 | `options` | `{title, description?}[]?` | `[]` | Multiple-choice options. The schema is a flat object shape (no `anyOf`, which some provider proxies strip or reject); plain strings and common alias keys (`label`, `text`, `value`, `name`, `option`) are still accepted at runtime |
 | `allowMultiple` | `boolean?` | `false` | Enable multi-select mode |
 | `allowFreeform` | `boolean?` | `true` | Add a "Type something" freeform option |
-| `allowComment` | `boolean?` | `false` | Expose a user-toggleable extra-context option in the custom UI (`ctrl+g` or the toggle row) and collect an optional comment in fallback dialogs |
+| `allowComment` | `boolean?` | env var or `false` | Expose a user-toggleable extra-context option in the custom UI (`ctrl+g` or the toggle row) and collect an optional comment in fallback dialogs |
 | `displayMode` | `"overlay" \| "inline"?` | env var or `"overlay"` | Controls custom UI rendering: `overlay` shows the centered modal (current behavior), `inline` renders without overlay framing |
 | `overlayToggleKey` | `string?` | env var or `"alt+o"` | Shortcut for hiding/showing the overlay popup (overlay mode only). Pi-TUI key spec, e.g. `"alt+o"`, `"ctrl+shift+h"`. Pass `"off"` to disable. |
 | `commentToggleKey` | `string?` | env var or `"ctrl+g"` | Shortcut for toggling the optional comment/extra-context row when `allowComment: true`. Pass `"off"` to disable. |
@@ -95,9 +95,12 @@ Configure your defaults globally by setting these in your shell profile (`~/.zsh
 
 ```bash
 export PI_ASK_USER_DISPLAY_MODE=inline
+export PI_ASK_USER_ALLOW_COMMENT=true
 export PI_ASK_USER_OVERLAY_TOGGLE_KEY=alt+h
 export PI_ASK_USER_COMMENT_TOGGLE_KEY=alt+c
 ```
+
+Environment variables must be present in the process that launches Pi. If Pi is launched from a desktop app or a different shell, changes in `~/.zshrc` may not be inherited; launch Pi from a terminal where `echo $PI_ASK_USER_DISPLAY_MODE` shows the expected value.
 
 ### Display mode
 
@@ -108,6 +111,14 @@ Effective order:
 3. Fallback default: `"overlay"`
 
 Unrecognised values are silently ignored and fall back to `"overlay"`.
+
+### Optional comments
+
+Effective order:
+
+1. Per-call `allowComment` parameter (if provided)
+2. `PI_ASK_USER_ALLOW_COMMENT` (`true`, `1`, `yes`, or `on`; corresponding false values are also accepted)
+3. Fallback default: `false`
 
 ### Shortcuts
 
@@ -132,6 +143,10 @@ While an `ask_user` prompt is open:
 | `↑` / `↓`, `ctrl+k` / `ctrl+j` | Navigate options. `ctrl+k` / `ctrl+j` (vim-style) work while typing in searchable prompts without disturbing the filter. |
 
 If you prefer never to see the overlay, set `displayMode: "inline"` per call or `PI_ASK_USER_DISPLAY_MODE=inline` globally.
+
+## Known limitations
+
+- **Overlays cannot draw over inline images** ([#8](https://github.com/edlsh/pi-ask-user/issues/8)). Pi-TUI's overlay compositor skips rows occupied by terminal images (Kitty/iTerm2 graphics), so an `ask_user` overlay that intersects an image is partially or fully invisible. This must be fixed upstream in pi-tui (`compositeLineAt` returns image rows unchanged). Until then, `displayMode: "inline"` (or `PI_ASK_USER_DISPLAY_MODE=inline`) sidesteps the overlay compositor entirely and should keep the prompt visible.
 
 ## Result details
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -100,6 +100,13 @@ function createKeybindings(overrides: Partial<Record<string, string[]>> = {}) {
    };
 }
 
+type AskComponentFactory = (
+   tui: unknown,
+   theme: unknown,
+   keybindings: unknown,
+   done: (value: unknown) => void,
+) => { handleInput(data: string): void };
+
 beforeAll(() => {
    // Model the failure mode from https://github.com/edlsh/pi-ask-user/issues/17.
    // `getMarkdownTheme()` returns a bag of closures that read through a Proxy
@@ -385,6 +392,30 @@ describe("ask_user", () => {
             hasUI: true,
             ui: {
                custom: async (_factory: any, options: any) => {
+                  capturedOptions = options;
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(capturedOptions).toBeUndefined();
+   });
+
+   test("normalizes PI_ASK_USER_DISPLAY_MODE before applying it", async () => {
+      stubEnv("PI_ASK_USER_DISPLAY_MODE", " INLINE ");
+      const tool = await setupTool();
+      let capturedOptions: unknown;
+
+      await tool.execute(
+         "tool-call-id",
+         { question: "Which option should we use?", options: ["A", "B"] },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (_factory: unknown, options: unknown) => {
                   capturedOptions = options;
                   return null;
                },
@@ -1221,6 +1252,80 @@ describe("ask_user", () => {
       expect(result.isError).not.toBe(true);
       expect(result.details.response).toEqual({ kind: "selection", selections: ["Chrome"] });
       expect(result.details.cancelled).toBe(false);
+   });
+
+   test("uses PI_ASK_USER_ALLOW_COMMENT when allowComment is omitted", async () => {
+      stubEnv("PI_ASK_USER_ALLOW_COMMENT", "true");
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         { question: "Which option should we use?", options: ["Chrome", "Firefox"] },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: AskComponentFactory) => {
+                  let resolved: unknown;
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     (value) => { resolved = value; },
+                  );
+                  component.handleInput("ctrl+g");
+                  component.handleInput("enter");
+                  // Discriminator: with the env preference applied, the first
+                  // enter enters comment mode instead of resolving.
+                  expect(resolved).toBeUndefined();
+                  editorText = "Prefer the default browser everywhere.";
+                  component.handleInput("enter");
+                  return resolved ?? null;
+               },
+            },
+         },
+      );
+
+      expect(result.details.response).toEqual({
+         kind: "selection",
+         selections: ["Chrome"],
+         comment: "Prefer the default browser everywhere.",
+      });
+   });
+
+   test("call-level allowComment false overrides PI_ASK_USER_ALLOW_COMMENT", async () => {
+      stubEnv("PI_ASK_USER_ALLOW_COMMENT", "true");
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         { question: "Which option should we use?", options: ["Chrome", "Firefox"], allowComment: false },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: AskComponentFactory) => {
+                  let resolved: unknown;
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     (value) => { resolved = value; },
+                  );
+                  component.handleInput("ctrl+g");
+                  component.handleInput("enter");
+                  // Discriminator: per-call false wins, so ctrl+g is a no-op
+                  // and the first enter resolves the selection immediately.
+                  expect(resolved).not.toBeUndefined();
+                  return resolved ?? null;
+               },
+            },
+         },
+      );
+
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["Chrome"] });
    });
 
    test("treats out-of-range number keys as search input in single-select mode", async () => {

--- a/index.ts
+++ b/index.ts
@@ -160,6 +160,24 @@ function normalizeOptionalComment(text: string | null | undefined): string | und
    return trimmed ? trimmed : undefined;
 }
 
+function parseBooleanPreference(value: string | undefined): boolean | undefined {
+   if (value === undefined) return undefined;
+   switch (value.trim().toLowerCase()) {
+      case "1":
+      case "true":
+      case "yes":
+      case "on":
+         return true;
+      case "0":
+      case "false":
+      case "no":
+      case "off":
+         return false;
+      default:
+         return undefined;
+   }
+}
+
 function createFreeformResponse(text: string | null | undefined): AskResponse | null {
    const trimmed = text?.trim();
    return trimmed ? { kind: "freeform", text: trimmed } : null;
@@ -1849,7 +1867,7 @@ export default function(pi: ExtensionAPI) {
             Type.Boolean({ description: "Add a freeform text option. Default: true" }),
          ),
          allowComment: Type.Optional(
-            Type.Boolean({ description: "Collect an optional comment after selecting one or more options. Default: false" }),
+            Type.Boolean({ description: "Collect an optional comment after selecting one or more options. Default: PI_ASK_USER_ALLOW_COMMENT env var if set, otherwise false." }),
          ),
          displayMode: Type.Optional(
             StringEnum(["overlay", "inline"] as const, {
@@ -1887,16 +1905,19 @@ export default function(pi: ExtensionAPI) {
             options: rawOptions = [],
             allowMultiple = false,
             allowFreeform = true,
-            allowComment = false,
+            allowComment: requestedAllowComment,
             displayMode,
             overlayToggleKey,
             commentToggleKey,
             timeout,
          } = params as AskParams;
-         const envMode = process.env.PI_ASK_USER_DISPLAY_MODE;
+         const envMode = process.env.PI_ASK_USER_DISPLAY_MODE?.trim().toLowerCase();
          const envDisplayMode: AskDisplayMode | undefined =
             envMode === "overlay" || envMode === "inline" ? envMode : undefined;
          const effectiveDisplayMode: AskDisplayMode = displayMode ?? envDisplayMode ?? "overlay";
+         const allowComment = requestedAllowComment
+            ?? parseBooleanPreference(process.env.PI_ASK_USER_ALLOW_COMMENT)
+            ?? false;
          const shortcuts: ResolvedAskShortcuts = {
             overlayToggle: resolveShortcut(
                overlayToggleKey,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-ask-user",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Interactive ask_user tool for pi-coding-agent with searchable split-pane selection UI, multi-select, and freeform input",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

Audit of the open issues, shipping what is verifiably fixable in this extension:

- **`PI_ASK_USER_ALLOW_COMMENT` env preference** — per-call `allowComment` > env > `false`, tolerant boolean parsing (`1/true/yes/on` + negatives). Closes #26.
- **Display-mode env hardening (#24)** — `PI_ASK_USER_DISPLAY_MODE` is trimmed/lowercased before matching; README documents that Pi must inherit `PI_ASK_USER_*` from its launching process. Diagnostic only: the reported repro (valid lowercase `inline`) points at env inheritance, not parsing.
- **Known-limitations doc (#8)** — pi-tui's overlay compositor (`compositeLineAt`) returns image rows unchanged, so overlays are invisible where Kitty/iTerm2 images sit. Root cause is upstream in pi-tui; README documents `displayMode: "inline"` as the workaround.
- Not included: a #25 (host notification) change — a `ctx.ui.notify` toast was evaluated and removed as ineffective (Orca's status integration consumes Pi lifecycle hooks and never observes UI toasts). #25 needs a host-consumable waiting contract; PR #27 is the open candidate for that.

## Tests

- `bun test`: 68 pass, 0 fail. New tests assert the comment-mode lifecycle (env-enabled: first `enter` must *not* resolve; per-call `false`: first `enter` must resolve immediately) so env application and precedence are each discriminated.
- `npm pack --dry-run` clean.

Releases 0.13.0.