### PR TITLE
feat: make ask_user usable on phone-sized terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Mobile-first prompt guidance with advisory question, context, and option budgets in the registered tool and bundled skill.
+- Responsive context collapse for overlay and inline prompts; oversized context preserves the full value while keeping the question and choices visible, and `ctrl+e` toggles the expanded view.
+
 ## [0.13.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.0) - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ While an `ask_user` prompt is open:
 |-----|--------|
 | `alt+o` (configurable via `overlayToggleKey`) | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you which key brings it back. |
 | `ctrl+g` (configurable via `commentToggleKey`) | Toggle the optional comment/extra-context row (when `allowComment: true`). |
-| `ctrl+e` | Expand or collapse oversized context while choosing an option. |
+| `ctrl+e` | Expand or collapse oversized context while choosing an option. If another configured ask shortcut owns it, the prompt shows `ctrl+x` or `ctrl+y` instead. |
 | `enter` | Confirm the focused option, submit a freeform response, or submit/skip an optional comment. |
 | `esc` | Clear the search filter, exit freeform/comment mode, or cancel the prompt. |
 | `↑` / `↓`, `ctrl+k` / `ctrl+j` | Navigate options. `ctrl+k` / `ctrl+j` (vim-style) work while typing in searchable prompts without disturbing the filter. |
@@ -148,7 +148,7 @@ If you prefer never to see the overlay, set `displayMode: "inline"` per call or 
 
 ### Mobile-sized terminals
 
-The bundled skill asks models to keep questions and decision context concise. If context still wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press `ctrl+e` to expand or collapse the complete context; expanded context remains scrollable with the existing prompt-scroll keys.
+The bundled skill asks models to keep questions and decision context concise. If context still wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press the context key shown in the prompt (`ctrl+e` by default) to expand or collapse the complete context; expanded context remains bounded and scrollable with the existing prompt-scroll keys in both display modes.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ High-quality video: [ask-user-demo.mp4](./media/ask-user-demo.mp4)
 - Optional freeform responses
 - User-toggleable extra context on structured selections
 - Context display support
+- Mobile-first question guidance plus responsive context collapse that keeps the question and choices visible on small terminals without discarding full context
 - Configurable display mode: `overlay` (modal, default) or `inline` (rendered directly in the flow)
 - Runtime overlay toggle: press the configured overlay-toggle key (`alt+o` by default, configurable per call or via env var) while the prompt is open to temporarily hide/show the popup so you can read prior agent output, then press it again to bring it back
 - Pi-TUI-aligned keybinding and editor behavior
@@ -138,11 +139,16 @@ While an `ask_user` prompt is open:
 |-----|--------|
 | `alt+o` (configurable via `overlayToggleKey`) | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you which key brings it back. |
 | `ctrl+g` (configurable via `commentToggleKey`) | Toggle the optional comment/extra-context row (when `allowComment: true`). |
+| `ctrl+e` | Expand or collapse oversized context while choosing an option. |
 | `enter` | Confirm the focused option, submit a freeform response, or submit/skip an optional comment. |
 | `esc` | Clear the search filter, exit freeform/comment mode, or cancel the prompt. |
 | `↑` / `↓`, `ctrl+k` / `ctrl+j` | Navigate options. `ctrl+k` / `ctrl+j` (vim-style) work while typing in searchable prompts without disturbing the filter. |
 
 If you prefer never to see the overlay, set `displayMode: "inline"` per call or `PI_ASK_USER_DISPLAY_MODE=inline` globally.
+
+### Mobile-sized terminals
+
+The bundled skill asks models to keep questions and decision context concise. If context still wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press `ctrl+e` to expand or collapse the complete context; expanded context remains scrollable with the existing prompt-scroll keys.
 
 ## Known limitations
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1635,7 +1635,7 @@ describe("ask_user", () => {
       const joined = rendered.join("\n").replace(/\s+/g, " ");
       expect(joined).toContain("Which deployment strategy should we");
       expect(joined).toContain("use?");
-      expect(joined).toContain("Alpha");
+      expect(joined).toContain("→ 1. Alpha");
       expect(joined).toContain("Context (");
       expect(joined).toContain("ctrl+e");
       expect(joined).not.toContain("Decision-critical context detail.");
@@ -1904,6 +1904,50 @@ describe("ask_user", () => {
       expect(longOutput).not.toContain("Long context detail.");
    });
 
+   test("keeps medium inline context expanded until the user collapses it", async () => {
+      const tool = await setupTool();
+      let firstExpanded = "";
+      let secondExpanded = "";
+      let collapsedAgain = "";
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: Array.from({ length: 6 }, (_, index) => `Medium context line ${index}`).join("\n"),
+            options: ["Alpha", "Beta"],
+            displayMode: "inline",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(60);
+                  component.handleInput("ctrl+e");
+                  firstExpanded = component.render(60).join("\n");
+                  secondExpanded = component.render(60).join("\n");
+                  component.handleInput("ctrl+e");
+                  collapsedAgain = component.render(60).join("\n");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(firstExpanded).toContain("Medium context line 5");
+      expect(secondExpanded).toContain("Medium context line 5");
+      expect(collapsedAgain).toContain("Context (");
+      expect(collapsedAgain).not.toContain("Medium context line 5");
+   });
+
    test("bounds and scrolls expanded context in inline mode", async () => {
       const tool = await setupTool();
       let expanded: string[] = [];
@@ -1991,6 +2035,47 @@ describe("ask_user", () => {
       expect(help).toContain("ctrl+e toggle context");
       expect(help).toContain("ctrl+x expand context");
       expect(commentEnabled).toBe(true);
+      expect(expanded).toContain("Long context detail.");
+   });
+
+   test("moves the context toggle when the overlay shortcut owns ctrl+e", async () => {
+      const tool = await setupTool();
+      let help = "";
+      let expanded = "";
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: "Long context detail. ".repeat(80),
+            options: ["Alpha", "Beta"],
+            overlayToggleKey: "ctrl+e",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 12 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(50);
+                  help = (component as any).helpText.render(120).join("\n");
+                  component.handleInput("ctrl+x");
+                  component.render(50);
+                  component.handleInput("end");
+                  expanded = component.render(50).join("\n");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(help).toContain("ctrl+x expand context");
       expect(expanded).toContain("Long context detail.");
    });
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1904,6 +1904,96 @@ describe("ask_user", () => {
       expect(longOutput).not.toContain("Long context detail.");
    });
 
+   test("bounds and scrolls expanded context in inline mode", async () => {
+      const tool = await setupTool();
+      let expanded: string[] = [];
+      let scrolled: string[] = [];
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: Array.from({ length: 20 }, (_, index) => `Inline context line ${index}`).join("\n"),
+            options: ["Alpha", "Beta"],
+            displayMode: "inline",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 12 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(50);
+                  component.handleInput("ctrl+e");
+                  expanded = component.render(50);
+                  component.handleInput("end");
+                  scrolled = component.render(50);
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(expanded.length).toBeLessThanOrEqual(10);
+      expect(expanded.join("\n")).toContain("Alpha");
+      expect(scrolled.join("\n")).toContain("Inline context line 19");
+      expect(scrolled.join("\n")).toContain("Alpha");
+      expect(scrolled.join("\n")).toContain("PgUp/P");
+   });
+
+   test("moves the context toggle when a configured shortcut owns ctrl+e", async () => {
+      const tool = await setupTool();
+      let help = "";
+      let commentEnabled = false;
+      let expanded = "";
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: "Long context detail. ".repeat(80),
+            options: ["Alpha", "Beta"],
+            allowComment: true,
+            commentToggleKey: "ctrl+e",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 12 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(50);
+                  help = (component as any).helpText.render(120).join("\n");
+                  component.handleInput("ctrl+e");
+                  commentEnabled = (component as any).singleSelectList.isCommentEnabled();
+                  component.handleInput("ctrl+x");
+                  component.render(50);
+                  component.handleInput("end");
+                  expanded = component.render(50).join("\n");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(help).toContain("ctrl+e toggle context");
+      expect(help).toContain("ctrl+x expand context");
+      expect(commentEnabled).toBe(true);
+      expect(expanded).toContain("Long context detail.");
+   });
+
    test("submits immediately when the comment toggle is off", async () => {
       const tool = await setupTool();
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1599,15 +1599,58 @@ describe("ask_user", () => {
       expect(rendered).toContain("The alpha option keeps the rollout conservative.");
    });
 
-   test("keeps the top prompt, answers, and help visible when a long overlay prompt overflows", async () => {
+   test.each([
+      { width: 40, rows: 12 },
+      { width: 60, rows: 20 },
+   ])("keeps the question, collapsed context, and a choice visible at $width x $rows", async ({ width, rows }) => {
       const tool = await setupTool();
       let rendered: string[] = [];
-      let capturedOptions: any;
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which deployment strategy should we use?",
+            context: "Decision-critical context detail. ".repeat(80),
+            options: ["Alpha", "Beta"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  rendered = component.render(width);
+                  return null;
+               },
+            },
+         },
+      );
+
+      const joined = rendered.join("\n").replace(/\s+/g, " ");
+      expect(joined).toContain("Which deployment strategy should we");
+      expect(joined).toContain("use?");
+      expect(joined).toContain("Alpha");
+      expect(joined).toContain("Context (");
+      expect(joined).toContain("ctrl+e");
+      expect(joined).not.toContain("Decision-critical context detail.");
+   });
+
+   test("expands and re-collapses long context without losing filtered selection", async () => {
+      const tool = await setupTool();
+      let collapsed = "";
+      let expanded = "";
+      let recollapsed = "";
 
       const result = await tool.execute(
          "tool-call-id",
          {
-            question: "This is a very long question. ".repeat(80),
+            question: "Which option should we use?",
             context: "Context detail. ".repeat(80),
             options: ["Alpha", "Beta"],
          },
@@ -1616,30 +1659,35 @@ describe("ask_user", () => {
          {
             hasUI: true,
             ui: {
-               custom: async (factory: any, options: any) => {
-                  capturedOptions = options;
+               custom: async (factory: any) => {
+                  let resolved: unknown;
                   const component = factory(
                      { requestRender() { }, terminal: { rows: 12 } },
                      createTheme(),
                      createKeybindings(),
-                     () => { },
+                     (value: unknown) => { resolved = value; },
                   );
-                  rendered = component.render(50);
-                  return null;
+                  component.handleInput("b");
+                  collapsed = component.render(50).join("\n");
+                  component.handleInput("ctrl+e");
+                  component.render(50);
+                  component.handleInput("end");
+                  expanded = component.render(50).join("\n");
+                  component.handleInput("ctrl+e");
+                  recollapsed = component.render(50).join("\n");
+                  component.handleInput("enter");
+                  return resolved ?? null;
                },
             },
          },
       );
 
-      const joined = rendered.join("\n");
-      expect(result.isError).not.toBe(true);
-      expect(capturedOptions.overlay).toBe(true);
-      expect(rendered.length).toBeLessThanOrEqual(10);
-      expect(joined).toContain("Question");
-      expect(joined).toContain("This is a very long question.");
-      expect(joined).toContain("Alpha");
-      expect(joined).toContain("PgUp/PgDn prompt");
-      expect(joined).toContain("↓");
+      expect(collapsed).toContain("Context (");
+      expect(expanded).toContain("Context detail.");
+      expect(expanded).toContain("Beta");
+      expect(recollapsed).not.toContain("Context detail.");
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["Beta"] });
+      expect(result.details.context).toContain("Context detail.");
    });
 
    test("scrolls the prompt pane without hiding answers or help", async () => {
@@ -1671,6 +1719,8 @@ describe("ask_user", () => {
                      () => { },
                   );
                   initialRendered = component.render(50);
+                  component.handleInput("ctrl+e");
+                  component.render(50);
                   component.handleInput("end");
                   scrolledRendered = component.render(50);
                   component.handleInput("home");
@@ -1685,7 +1735,8 @@ describe("ask_user", () => {
       expect(initialRendered.join("\n")).toContain("Question line 0");
       expect(scrolledRendered.join("\n")).toContain("Context line 7");
       expect(scrolledRendered.join("\n")).toContain("Alpha");
-      expect(scrolledRendered.join("\n")).toContain("PgUp/PgDn prompt");
+      expect(scrolledRendered.join("\n")).toContain("ctrl+e collapse context");
+      expect(scrolledRendered.join("\n")).toContain("PgUp/P");
       expect(restoredRendered.join("\n")).toContain("Question line 0");
    });
 
@@ -1815,6 +1866,42 @@ describe("ask_user", () => {
 
       expect(result.isError).not.toBe(true);
       expect(rendered.length).toBeGreaterThan(10);
+   });
+
+   test("collapses oversized context in inline mode but leaves short context expanded", async () => {
+      const tool = await setupTool();
+      const render = async (context: string) => {
+         let output = "";
+         await tool.execute(
+            "tool-call-id",
+            { question: "Pick one", context, options: ["Alpha", "Beta"], displayMode: "inline" },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (factory: any) => {
+                     const component = factory(
+                        { requestRender() { }, terminal: { rows: 12 } },
+                        createTheme(),
+                        createKeybindings(),
+                        () => { },
+                     );
+                     output = component.render(40).join("\n");
+                     return null;
+                  },
+               },
+            },
+         );
+         return output;
+      };
+
+      const shortOutput = await render("Short context.");
+      const longOutput = await render("Long context detail. ".repeat(80));
+      expect(shortOutput).toContain("Short context.");
+      expect(shortOutput).not.toContain("Context (");
+      expect(longOutput).toContain("Context (");
+      expect(longOutput).not.toContain("Long context detail.");
    });
 
    test("submits immediately when the comment toggle is off", async () => {

--- a/index.test.ts
+++ b/index.test.ts
@@ -201,6 +201,9 @@ beforeAll(() => {
 });
 
 type RegisteredTool = {
+   description: string;
+   promptSnippet?: string;
+   promptGuidelines?: string[];
    execute: (...args: any[]) => Promise<any>;
    renderResult: (result: any, options: any, theme: any) => any;
 };
@@ -252,6 +255,36 @@ describe("ask_user", () => {
    test("registers with executionMode 'sequential' so the agent loop awaits the user's answer before other tool calls run", async () => {
       const tool = await setupTool();
       expect((tool as any).executionMode).toBe("sequential");
+   });
+
+   test("registers synchronized mobile-first prompt guidance", async () => {
+      const tool = await setupTool();
+      const guidance = [
+         tool.description,
+         tool.promptSnippet,
+         ...(tool.promptGuidelines ?? []),
+      ].join("\n");
+
+      expect(guidance).toContain("120 characters");
+      expect(guidance).toContain("240 characters");
+      expect(guidance).toContain("three short lines");
+      expect(guidance).toContain("2-4 options");
+      expect(guidance).toContain("long preamble");
+   });
+
+   test("bundled skill carries the same mobile-first budgets", async () => {
+      const skill = await Bun.file("skills/ask-user/SKILL.md").text();
+      const reference = await Bun.file(
+         "skills/ask-user/references/ask-user-skill-extension-spec.md",
+      ).text();
+
+      for (const text of [skill, reference]) {
+         expect(text).toContain("120 characters");
+         expect(text).toContain("240 characters");
+         expect(text).toContain("three short lines");
+         expect(text).toContain("2-4 options");
+         expect(text).toContain("long preamble");
+      }
    });
 
    test("uses overlay mode by default", async () => {

--- a/index.ts
+++ b/index.ts
@@ -380,8 +380,7 @@ const FREEFORM_SENTINEL = "\u270f\ufe0f Type custom response...";
 const COMMENT_TOGGLE_LABEL = "Add extra context after selection";
 const DEFAULT_OVERLAY_TOGGLE_KEY = "alt+o";
 const DEFAULT_COMMENT_TOGGLE_KEY = "ctrl+g";
-const CONTEXT_TOGGLE_KEY = Key.ctrl("e");
-const CONTEXT_TOGGLE_LABEL = "ctrl+e";
+const CONTEXT_TOGGLE_KEYS = [Key.ctrl("e"), Key.ctrl("x"), Key.ctrl("y")];
 const INLINE_CONTEXT_MAX_ROWS = 3;
 
 // Vim-style aliases for navigating option lists. ctrl+j/k are safe in the
@@ -1174,6 +1173,9 @@ class AskComponent extends Container {
    private renderInlineLayout(width: number, innerWidth: number): string[] {
       const fullContextLines = this.buildFullContextLines(innerWidth);
       this.setContextIsCollapsible(fullContextLines.length > INLINE_CONTEXT_MAX_ROWS);
+      if (this.contextExpanded) {
+         return this.renderOverlayLayout(width, innerWidth);
+      }
       const bodyLines = [
          ...this.buildPromptLines(innerWidth, fullContextLines),
          "",
@@ -1283,10 +1285,19 @@ class AskComponent extends Container {
       this.updateHelpText();
    }
 
+   private getContextToggleKey(): string {
+      const reserved = new Set(
+         [this.shortcuts.overlayToggle, this.shortcuts.commentToggle]
+            .filter((shortcut) => !shortcut.disabled)
+            .map((shortcut) => shortcut.spec),
+      );
+      return CONTEXT_TOGGLE_KEYS.find((key) => !reserved.has(key)) ?? CONTEXT_TOGGLE_KEYS[0]!;
+   }
+
    private buildContextDisplayLines(fullContextLines: string[], width: number): string[] {
       if (fullContextLines.length === 0) return [];
       if (!this.contextIsCollapsible || this.contextExpanded) return fullContextLines;
-      const label = `Context (${fullContextLines.length} lines) — ${CONTEXT_TOGGLE_LABEL} expand`;
+      const label = `Context (${fullContextLines.length} lines) — ${this.getContextToggleKey()} expand`;
       return [truncateToWidth(this.theme.fg("dim", label), width, "")];
    }
 
@@ -1537,7 +1548,7 @@ class AskComponent extends Container {
       const overlayHint = this.displayMode === "overlay" && !this.shortcuts.overlayToggle.disabled
          ? literalHint(theme, this.shortcuts.overlayToggle.spec, "hide")
          : null;
-      const promptScrollHint = this.displayMode === "overlay"
+      const promptScrollHint = this.displayMode === "overlay" || this.contextExpanded
          ? literalHint(theme, "PgUp/PgDn", "prompt")
          : null;
       const commentHint = this.allowComment && !this.shortcuts.commentToggle.disabled
@@ -1546,7 +1557,7 @@ class AskComponent extends Container {
       const contextHint = this.contextIsCollapsible
          ? literalHint(
             theme,
-            CONTEXT_TOGGLE_LABEL,
+            this.getContextToggleKey(),
             this.contextExpanded ? "collapse context" : "expand context",
          )
          : null;
@@ -1772,7 +1783,8 @@ class AskComponent extends Container {
    }
 
    private setPromptScrollOffset(nextOffset: number): boolean {
-      if (this.displayMode !== "overlay" || this.promptMaxScrollOffset <= 0) return false;
+      if (this.displayMode !== "overlay" && !this.contextExpanded) return false;
+      if (this.promptMaxScrollOffset <= 0) return false;
       const clamped = Math.max(0, Math.min(Math.floor(nextOffset), this.promptMaxScrollOffset));
       const changed = clamped !== this.promptScrollOffset;
       this.promptScrollOffset = clamped;
@@ -1780,7 +1792,8 @@ class AskComponent extends Container {
    }
 
    private handlePromptScrollInput(data: string): boolean {
-      if (this.displayMode !== "overlay" || this.promptMaxScrollOffset <= 0) return false;
+      if (this.displayMode !== "overlay" && !this.contextExpanded) return false;
+      if (this.promptMaxScrollOffset <= 0) return false;
       // Prompt scrolling is select-mode only: in freeform/comment modes the
       // editor owns PageUp/PageDown (tui.editor.pageUp/pageDown) for paging
       // through long input, so intercepting them here would steal editor keys.
@@ -1814,7 +1827,7 @@ class AskComponent extends Container {
    }
 
    handleInput(data: string): void {
-      if (matchesKey(data, CONTEXT_TOGGLE_KEY) && this.toggleContext()) {
+      if (matchesKey(data, this.getContextToggleKey() as any) && this.toggleContext()) {
          return;
       }
       if (this.handlePromptScrollInput(data)) {

--- a/index.ts
+++ b/index.ts
@@ -380,6 +380,9 @@ const FREEFORM_SENTINEL = "\u270f\ufe0f Type custom response...";
 const COMMENT_TOGGLE_LABEL = "Add extra context after selection";
 const DEFAULT_OVERLAY_TOGGLE_KEY = "alt+o";
 const DEFAULT_COMMENT_TOGGLE_KEY = "ctrl+g";
+const CONTEXT_TOGGLE_KEY = Key.ctrl("e");
+const CONTEXT_TOGGLE_LABEL = "ctrl+e";
+const INLINE_CONTEXT_MAX_ROWS = 3;
 
 // Vim-style aliases for navigating option lists. ctrl+j/k are safe in the
 // searchable single-select because they don't collide with fuzzy-search input.
@@ -1046,6 +1049,8 @@ class AskComponent extends Container {
    private promptScrollOffset = 0;
    private promptMaxScrollOffset = 0;
    private promptViewportRows = 0;
+   private contextIsCollapsible = false;
+   private contextExpanded = false;
 
    // Static layout components
    private titleText: Text;
@@ -1163,7 +1168,20 @@ class AskComponent extends Container {
          this.ensureSingleSelectList().setMaxVisibleRows(12);
       }
 
-      return this.frameRawLines(super.render(innerWidth), width, innerWidth);
+      return this.renderInlineLayout(width, innerWidth);
+   }
+
+   private renderInlineLayout(width: number, innerWidth: number): string[] {
+      const fullContextLines = this.buildFullContextLines(innerWidth);
+      this.setContextIsCollapsible(fullContextLines.length > INLINE_CONTEXT_MAX_ROWS);
+      const bodyLines = [
+         ...this.buildPromptLines(innerWidth, fullContextLines),
+         "",
+         ...this.modeContainer.render(innerWidth),
+         "",
+         ...this.helpText.render(innerWidth),
+      ];
+      return this.frameBodyLines(bodyLines, width, innerWidth);
    }
 
    private getOverlayMaxRenderLines(): number {
@@ -1177,8 +1195,20 @@ class AskComponent extends Container {
       if (maxLines === 2) return [this.renderTopBorder(width), this.renderBottomBorder(width)];
 
       const bodyCapacity = Math.max(0, maxLines - 2);
-      const promptLines = this.buildPromptLines(innerWidth);
-      const helpFullLines = this.helpText.render(innerWidth);
+      let helpFullLines = this.helpText.render(innerWidth);
+      const questionLines = this.buildQuestionLines(innerWidth);
+      const fullContextLines = this.buildFullContextLines(innerWidth);
+      const shouldCollapse = this.mode === "select"
+         ? this.shouldCollapseContextForOverlay(
+            questionLines.length,
+            fullContextLines.length,
+            bodyCapacity,
+            helpFullLines.length,
+         )
+         : this.contextIsCollapsible;
+      this.setContextIsCollapsible(shouldCollapse);
+      helpFullLines = this.helpText.render(innerWidth);
+      const promptLines = this.buildPromptLines(innerWidth, fullContextLines);
       const helpBudget = this.getOverlayHelpBudget(bodyCapacity, helpFullLines.length);
       const contentRows = Math.max(0, bodyCapacity - helpBudget);
 
@@ -1199,9 +1229,10 @@ class AskComponent extends Container {
             modeBudget = Math.max(modeMinRows, modeBudget);
             promptBudget = promptAndModeRows - modeBudget;
 
+            const usefulPromptTarget = this.contextIsCollapsible && !this.contextExpanded ? 3 : 2;
             const usefulPromptRows = Math.min(
                promptLines.length,
-               promptAndModeRows >= modeMinRows + 2 ? 2 : promptMinRows,
+               promptAndModeRows >= modeMinRows + usefulPromptTarget ? usefulPromptTarget : promptMinRows,
             );
             if (promptBudget < usefulPromptRows && modeBudget > modeMinRows) {
                const shiftedRows = Math.min(usefulPromptRows - promptBudget, modeBudget - modeMinRows);
@@ -1236,12 +1267,54 @@ class AskComponent extends Container {
       return this.frameBodyLines(bodyLines.slice(0, bodyCapacity), width, innerWidth);
    }
 
-   private buildPromptLines(width: number): string[] {
+   private buildQuestionLines(width: number): string[] {
+      return this.questionText.render(width);
+   }
+
+   private buildFullContextLines(width: number): string[] {
+      if (!this.contextComponent) return [];
+      return this.contextComponent.render(width);
+   }
+
+   private setContextIsCollapsible(value: boolean): void {
+      if (this.contextIsCollapsible === value) return;
+      this.contextIsCollapsible = value;
+      if (!value) this.contextExpanded = false;
+      this.updateHelpText();
+   }
+
+   private buildContextDisplayLines(fullContextLines: string[], width: number): string[] {
+      if (fullContextLines.length === 0) return [];
+      if (!this.contextIsCollapsible || this.contextExpanded) return fullContextLines;
+      const label = `Context (${fullContextLines.length} lines) — ${CONTEXT_TOGGLE_LABEL} expand`;
+      return [truncateToWidth(this.theme.fg("dim", label), width, "")];
+   }
+
+   private buildPromptLines(width: number, fullContextLines: string[]): string[] {
+      const questionLines = this.buildQuestionLines(width);
+      const contextLines = this.buildContextDisplayLines(fullContextLines, width);
+      const contextSeparator = this.contextIsCollapsible && !this.contextExpanded ? [] : [""];
       return [
-         ...this.titleText.render(width),
-         ...this.questionText.render(width),
-         ...(this.contextComponent ? ["", ...this.contextComponent.render(width)] : []),
+         ...questionLines,
+         ...(contextLines.length > 0 ? [...contextSeparator, ...contextLines] : []),
       ];
+   }
+
+   private shouldCollapseContextForOverlay(
+      questionRows: number,
+      contextRows: number,
+      bodyCapacity: number,
+      helpRows: number,
+   ): boolean {
+      if (contextRows === 0) return false;
+      const helpBudget = this.getOverlayHelpBudget(bodyCapacity, helpRows);
+      const contentRows = Math.max(0, bodyCapacity - helpBudget);
+      const separatorRows = contentRows >= 4 ? 1 : 0;
+      const promptCapacity = Math.max(
+         0,
+         contentRows - separatorRows - this.getMinimumModeRows(),
+      );
+      return questionRows + 1 + contextRows > promptCapacity;
    }
 
    private getOverlayHelpBudget(bodyCapacity: number, renderedHelpRows: number): number {
@@ -1253,7 +1326,7 @@ class AskComponent extends Container {
    private getMinimumModeRows(): number {
       if (this.mode === "freeform") return 5;
       if (this.mode === "comment") return 6;
-      return this.allowMultiple ? 3 : 4;
+      return 3;
    }
 
    private getPreferredModeRows(): number {
@@ -1470,6 +1543,13 @@ class AskComponent extends Container {
       const commentHint = this.allowComment && !this.shortcuts.commentToggle.disabled
          ? literalHint(theme, this.shortcuts.commentToggle.spec, "toggle context")
          : null;
+      const contextHint = this.contextIsCollapsible
+         ? literalHint(
+            theme,
+            CONTEXT_TOGGLE_LABEL,
+            this.contextExpanded ? "collapse context" : "expand context",
+         )
+         : null;
       if (this.mode === "freeform" || this.mode === "comment") {
          const alternateCancelKeys = this.keybindings
             .getKeys("tui.select.cancel")
@@ -1492,6 +1572,7 @@ class AskComponent extends Container {
             literalHint(theme, "↑↓", "navigate"),
             literalHint(theme, "space", "toggle"),
             commentHint,
+            contextHint,
             promptScrollHint,
             overlayHint,
             keybindingHint(theme, this.keybindings, "tui.select.confirm", "submit"),
@@ -1507,6 +1588,7 @@ class AskComponent extends Container {
          const hints = [
             literalHint(theme, "type", "filter"),
             commentHint,
+            contextHint,
             promptScrollHint,
             keybindingHint(theme, this.keybindings, "tui.editor.deleteCharBackward", "erase"),
             literalHint(theme, "↑↓", "navigate"),
@@ -1680,6 +1762,15 @@ class AskComponent extends Container {
       this.tui.requestRender();
    }
 
+   private toggleContext(): boolean {
+      if (this.mode !== "select" || !this.contextIsCollapsible) return false;
+      this.contextExpanded = !this.contextExpanded;
+      this.promptScrollOffset = 0;
+      this.invalidate();
+      this.tui.requestRender();
+      return true;
+   }
+
    private setPromptScrollOffset(nextOffset: number): boolean {
       if (this.displayMode !== "overlay" || this.promptMaxScrollOffset <= 0) return false;
       const clamped = Math.max(0, Math.min(Math.floor(nextOffset), this.promptMaxScrollOffset));
@@ -1723,6 +1814,9 @@ class AskComponent extends Container {
    }
 
    handleInput(data: string): void {
+      if (matchesKey(data, CONTEXT_TOGGLE_KEY) && this.toggleContext()) {
+         return;
+      }
       if (this.handlePromptScrollInput(data)) {
          this.tui.requestRender();
          return;

--- a/index.ts
+++ b/index.ts
@@ -1824,24 +1824,29 @@ export default function(pi: ExtensionAPI) {
       name: "ask_user",
       label: "Ask User",
       description:
-         "Ask the user a question with optional multiple-choice answers. Use this to gather information interactively. Ask exactly one focused question per call. Before calling, gather context with tools (read/web/ref) and pass a short summary via the context field.",
+         "Ask the user one focused question with optional choices. Keep it mobile-friendly: use a one-sentence question, optional decision-critical context, and concise options.",
       promptSnippet:
-         "Ask the user one focused question with optional multiple-choice answers to gather information interactively",
+         "Ask one concise, mobile-friendly question with optional multiple-choice answers",
       promptGuidelines: [
-         "Before calling ask_user, gather context with tools (read/web/ref) and pass a short summary via the context field.",
-         "Use ask_user when the user's intent is ambiguous, when a decision requires explicit user input, or when multiple valid options exist.",
-         "Ask exactly one focused question per ask_user call.",
-         "Do not combine multiple numbered, multipart, or unrelated questions into one ask_user prompt.",
+         "Before calling ask_user, gather evidence with tools, but include only decision-critical context in the prompt.",
+         "Keep ask_user mobile-friendly: target one question sentence and at most 120 characters; omit context when options are self-explanatory.",
+         "When context is needed, target at most 240 characters or three short lines. Do not restate the question or options in context.",
+         "Use 2-4 options where practical, with short titles and one-line descriptions.",
+         "Do not emit a long preamble immediately before ask_user.",
+         "Use ask_user when intent is ambiguous, explicit input is required, or multiple valid options exist.",
+         "Ask exactly one focused question per ask_user call; do not combine numbered, multipart, or unrelated questions.",
       ],
       // Block other tool calls in the same assistant turn until the user answers,
       // so the model can't batch ask_user with bash/edit/write and let those run
       // (potentially with side effects) before the user sees the prompt.
       executionMode: "sequential",
       parameters: Type.Object({
-         question: Type.String({ description: "The question to ask the user" }),
+         question: Type.String({
+            description: "One focused question in one sentence; target at most 120 characters",
+         }),
          context: Type.Optional(
             Type.String({
-               description: "Relevant context to show before the question (summary of findings)",
+               description: "Optional decision-critical context; omit when options are self-explanatory and target at most 240 characters or three short lines",
             }),
          ),
          options: Type.Optional(
@@ -1852,9 +1857,9 @@ export default function(pi: ExtensionAPI) {
                // and produce empty options. Plain strings are still accepted at
                // runtime for older transcripts. See issue #22.
                Type.Object({
-                  title: Type.String({ description: "Short title for this option" }),
+                  title: Type.String({ description: "Short title for this option; use 2-4 options where practical" }),
                   description: Type.Optional(
-                     Type.String({ description: "Longer description explaining this option" }),
+                     Type.String({ description: "One-line description explaining the option when needed" }),
                   ),
                }),
                { description: "List of options for the user to choose from" },

--- a/index.ts
+++ b/index.ts
@@ -1200,14 +1200,16 @@ class AskComponent extends Container {
       let helpFullLines = this.helpText.render(innerWidth);
       const questionLines = this.buildQuestionLines(innerWidth);
       const fullContextLines = this.buildFullContextLines(innerWidth);
-      const shouldCollapse = this.mode === "select"
-         ? this.shouldCollapseContextForOverlay(
-            questionLines.length,
-            fullContextLines.length,
-            bodyCapacity,
-            helpFullLines.length,
-         )
-         : this.contextIsCollapsible;
+      const shouldCollapse = this.displayMode === "inline"
+         ? this.contextIsCollapsible
+         : this.mode === "select"
+            ? this.shouldCollapseContextForOverlay(
+               questionLines.length,
+               fullContextLines.length,
+               bodyCapacity,
+               helpFullLines.length,
+            )
+            : this.contextIsCollapsible;
       this.setContextIsCollapsible(shouldCollapse);
       helpFullLines = this.helpText.render(innerWidth);
       const promptLines = this.buildPromptLines(innerWidth, fullContextLines);

--- a/skills/ask-user/SKILL.md
+++ b/skills/ask-user/SKILL.md
@@ -41,11 +41,7 @@ Before asking, gather context from available tools (`read`, `bash`, `exa`, `ref`
 Do not ask the user to decide blind.
 
 ### 3) Synthesize context
-Prepare a short neutral summary (3-7 bullets or short paragraph) covering:
-- current state
-- key constraints
-- trade-offs
-- recommendation (if any)
+Prepare only the decision-critical facts within the mobile-first prompt budget below. Include a recommendation when it materially helps the choice.
 
 ### 4) Ask one focused question
 Call `ask_user` with one decision at a time:
@@ -86,7 +82,22 @@ After attempt 2:
 - If boundary is `high_stakes` or `both`: **stop and mark blocked**. Do not keep asking.
 - If boundary is `ambiguous` only and user says “your call” or equivalent: proceed with the most reversible default and state assumptions explicitly.
 
+## Mobile-first prompt budget
+
+When calling `ask_user`:
+
+- ask one question in one sentence, targeting at most 120 characters;
+- omit `context` when the options are self-explanatory;
+- otherwise include only decision-critical context, targeting at most 240 characters or three short lines;
+- use 2-4 options where practical, with short titles and one-line descriptions;
+- do not restate the question or options in context;
+- do not emit a long preamble immediately before the tool call.
+
+These are generation targets, not reasons to withhold a necessary decision or reject longer resumed-session input.
+
 ## `ask_user` payload quality standard
+
+Apply the mobile-first prompt budget above to every payload.
 
 ### Question quality
 Use:

--- a/skills/ask-user/references/ask-user-skill-extension-spec.md
+++ b/skills/ask-user/references/ask-user-skill-extension-spec.md
@@ -32,11 +32,24 @@ Use this protocol whenever the trigger matrix says to ask.
 2. **Gather evidence**
    - read code/docs/logs first; do not ask blindly
 3. **Summarize context**
-   - prepare concise trade-off context (3–7 bullets or short paragraph)
+   - prepare only decision-critical facts within the mobile-first prompt budget below
 4. **Ask one focused question**
    - call `ask_user` for one decision at a time
 5. **Commit and proceed**
    - restate chosen option and implement accordingly
+
+### Mobile-first prompt budget
+
+When calling `ask_user`:
+
+- ask one question in one sentence, targeting at most 120 characters;
+- omit `context` when the options are self-explanatory;
+- otherwise include only decision-critical context, targeting at most 240 characters or three short lines;
+- use 2-4 options where practical, with short titles and one-line descriptions;
+- do not restate the question or options in context;
+- do not emit a long preamble immediately before the tool call.
+
+These are generation targets, not reasons to withhold a necessary decision or reject longer resumed-session input.
 
 ### Retry/cancel policy
 


### PR DESCRIPTION
## Summary

- Keep questions and context concise with mobile-first prompt guidance.
- Collapse oversized context so the question and choices stay visible.
- Add `ctrl+e` expansion with bounded scrolling in overlay and inline modes.
- Preserve selection and filter state while toggling context.

## Why

Long context can push the choices off a small terminal. This keeps the full context available without making the prompt unusable.

## Tested

- `bun test`: 77 pass
- `npm run check`
- Phone-sized Pi smoke test