### PR TITLE
Fix multi-select overlay viewport scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Multi-select overlays now size their variable-height option viewport from the available row budget, keeping focused options and freeform/comment controls visible while navigating and adapting to terminal resizes. Closes #33.
+
 ## [0.13.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.0) - 2026-07-12
 
 ### Added

--- a/index.test.ts
+++ b/index.test.ts
@@ -18,6 +18,14 @@ function wrapPlainText(text: string, width = 80): string[] {
    return lines.length > 0 ? lines : [""];
 }
 
+function truncatePlainText(text: string, width = 80, ellipsis = "…"): string {
+   const safeWidth = Math.max(0, Math.floor(width));
+   if (text.length <= safeWidth) return text;
+   if (!ellipsis) return text.slice(0, safeWidth);
+   if (safeWidth <= ellipsis.length) return ellipsis.slice(0, safeWidth);
+   return text.slice(0, safeWidth - ellipsis.length) + ellipsis;
+}
+
 class MockText {
    constructor(private text: string) { }
    render(width = 80) {
@@ -175,7 +183,10 @@ beforeAll(() => {
          }
       },
       Text: MockText,
-      truncateToWidth: (text: string) => text,
+      // Keep the test harness honest about visible width. Production layout
+      // relies on truncation being width-bounded even when the mock theme is
+      // ANSI-free.
+      truncateToWidth: truncatePlainText,
       wrapTextWithAnsi: (text: string, width = 80) => wrapPlainText(text, width),
       decodeKittyPrintable: (data: string) => (data.length === 1 ? data : undefined),
       fuzzyFilter: <T>(items: T[], query: string, getText: (item: T) => string) => {
@@ -1213,6 +1224,409 @@ describe("ask_user", () => {
       expect(result.isError).not.toBe(true);
       expect(result.details.response).toEqual({ kind: "selection", selections: ["Beta"] });
       expect(result.details.cancelled).toBe(false);
+   });
+
+   test("keeps every multi-select option and control focused within a small overlay viewport", async () => {
+      const tool = await setupTool();
+      const options = [
+         { title: "Alpha authored option title that wraps", description: "First authored option with enough detail to wrap." },
+         { title: "Beta", description: "Second authored option with enough detail to wrap." },
+         { title: "Gamma", description: "Third authored option with enough detail to wrap." },
+         { title: "Delta", description: "Fourth authored option with enough detail to wrap." },
+         { title: "Epsilon", description: "Fifth authored option with enough detail to wrap." },
+      ];
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which options should we use?",
+            context: "A long context pane that consumes rows before the multi-select list appears. ".repeat(4),
+            options,
+            allowMultiple: true,
+            allowFreeform: true,
+            allowComment: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const tui = { requestRender() { }, terminal: { rows: 12 } };
+                  const component = factory(tui, createTheme(), createKeybindings(), () => { });
+                  component.handleInput("space");
+
+                  for (let index = 0; index < options.length + 2; index++) {
+                     const rendered = component.render(40).join("\n");
+                     const compact = rendered.replace(/[\s│]/g, "");
+                     const focused = index < options.length
+                        ? `→${index + 1}.`
+                        : index === options.length
+                           ? "→[]Addextracontextafterselection"
+                           : "→Typesomething.—Enteracustomresponse";
+                     expect(compact).toContain(focused);
+                     if (index === 0) {
+                        expect(compact).toContain("Alphaauthoredoptiontitlethatwraps");
+                     }
+                     expect(rendered).toContain(`(${index + 1}/7)`);
+                     expect(rendered).not.toContain("…");
+                     if (index < options.length + 1) component.handleInput("down");
+                  }
+
+                  component.handleInput("down");
+                  const finalRendered = component.render(40).join("\n");
+                  expect(finalRendered.replace(/[\s│]/g, "")).toContain(
+                     "→1.[✓]Alphaauthoredoptiontitlethatwraps",
+                  );
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+   });
+
+   test("keeps a multi-select viewport centered and stable through the first half", async () => {
+      const tool = await setupTool();
+      const options = Array.from({ length: 10 }, (_, index) => ({ title: `Option ${index + 1}` }));
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which options should we use?",
+            options,
+            allowMultiple: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  const list = (component as any).multiSelectList as any;
+                  list.setMaxVisibleRows(6);
+                  // Initial focus is option 1; options 1–5 stay in place for
+                  // focus 1, 2, and 3. Option 4 shifts the window to 2–6.
+                  const content = () => list.render(40)
+                     .slice(0, -1)
+                     .map((line: string) => line.replace("→", " "))
+                     .join("\n");
+                  const first = content();
+                  component.handleInput("down");
+                  expect(content()).toBe(first);
+                  component.handleInput("down");
+                  expect(content()).toBe(first);
+                  component.handleInput("down");
+                  const shifted = list.render(40);
+                  expect(shifted).toHaveLength(6);
+                  expect(shifted.join("\n")).toContain("Option 6");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+   });
+
+   test("places variable-height multi-select padding on the anchored edge", async () => {
+      const tool = await setupTool();
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which options should we use?",
+            options: [
+               { title: "Option 1" },
+               { title: "Option 2" },
+               { title: "aaaaaaaaa bbbbbbbbb ccccccccc ddddddddd" },
+               { title: "Option 4" },
+               { title: "Option 5" },
+            ],
+            allowMultiple: true,
+            allowFreeform: false,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  const list = (component as any).multiSelectList as any;
+                  list.setMaxVisibleRows(6);
+
+                  component.handleInput("down");
+                  const early = list.render(18);
+                  expect(early).toHaveLength(6);
+                  expect(early[0]).toContain("Option 1");
+                  expect(early[1]).toContain("→");
+                  expect(early[1]).toContain("Option 2");
+                  expect(early.slice(2, 5)).toEqual(["", "", ""]);
+                  expect(early[5]).toBe("  (2/5)");
+
+                  component.handleInput("down");
+                  component.handleInput("down");
+                  const late = list.render(18);
+                  expect(late).toHaveLength(6);
+                  expect(late.slice(0, 3)).toEqual(["", "", ""]);
+                  expect(late[3]).toContain("→");
+                  expect(late[3]).toContain("Option 4");
+                  expect(late[4]).toContain("Option 5");
+                  expect(late[5]).toBe("  (4/5)");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+   });
+
+   test("recomputes the multi-select viewport when the terminal height changes", async () => {
+      const tool = await setupTool();
+      let smallRows = 0;
+      let largeRows = 0;
+      let shrunkRows = 0;
+      let shrunkOutput: string[] = [];
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which options should we use?",
+            options: ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"].map((title) => ({
+               title,
+               description: "A wrapped description for this option.",
+            })),
+            allowMultiple: true,
+            allowFreeform: true,
+            allowComment: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const tui = { requestRender() { }, terminal: { rows: 12 } };
+                  const component = factory(tui, createTheme(), createKeybindings(), () => { });
+                  component.render(40);
+                  smallRows = ((component as any).multiSelectList as any).render(40).length;
+
+                  tui.terminal.rows = 24;
+                  component.render(40);
+                  largeRows = ((component as any).multiSelectList as any).render(40).length;
+
+                  // Move focus to the late freeform control before shrinking;
+                  // the focused block must remain in the complete AskComponent output.
+                  for (let index = 0; index < 7; index++) component.handleInput("down");
+                  tui.terminal.rows = 10;
+                  shrunkOutput = component.render(40);
+                  shrunkRows = ((component as any).multiSelectList as any).render(40).length;
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+      expect(largeRows).toBeGreaterThan(smallRows);
+      expect(shrunkRows).toBeLessThan(largeRows);
+      const compactShrunkOutput = shrunkOutput.join("\n").replace(/[\s│]/g, "");
+      expect(compactShrunkOutput).toContain("→Typesomething.—Enteracustomresponse");
+      expect(shrunkOutput.length).toBeLessThanOrEqual(8);
+   });
+
+   test("allocates twelve rows to tall overlay multi-selects while retaining prompt scrolling", async () => {
+      const tool = await setupTool();
+      const terminalRows = 40;
+      const options = [
+         {
+            title: "Option 1",
+            description: "Option 1 description is deliberately long enough to wrap onto a second row in the list so the preferred pane budget is exercised fully. It keeps the first block taller than the rest.",
+         },
+         { title: "Option 2", description: "Option 2 description remains visible in the expanded list." },
+         { title: "Option 3", description: "Option 3 description remains visible in the expanded list." },
+         { title: "Option 4", description: "Option 4 description demonstrates content beyond the previous eight-row cap." },
+         { title: "Option 5", description: "Option 5 description demonstrates the additional visible content." },
+         { title: "Option 6", description: "Option 6 description is available below the focused rows." },
+         { title: "Option 7", description: "Option 7 description is available below the focused rows." },
+      ];
+      const context = Array.from(
+         { length: 30 },
+         (_, index) => `Prompt context line ${index + 1}: additional details remain reachable while the list is expanded.`,
+      ).join("\n");
+      let initialOutput: string[] = [];
+      let scrolledOutput: string[] = [];
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which options should we use?",
+            context,
+            options,
+            allowMultiple: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const tui = { requestRender() { }, terminal: { rows: terminalRows } };
+                  const component = factory(tui, createTheme(), createKeybindings(), () => { });
+                  initialOutput = component.render(80);
+
+                  const list = (component as any).multiSelectList as any;
+                  expect(list.maxVisibleRows).toBe(12);
+                  const previousCapRows = (() => {
+                     list.setMaxVisibleRows(8);
+                     return list.render(80);
+                  })();
+                  list.setMaxVisibleRows(12);
+                  const preferredRows = list.render(80);
+                  expect(preferredRows).toHaveLength(12);
+                  expect(preferredRows.length).toBeGreaterThan(previousCapRows.length);
+                  expect(preferredRows.join("\n")).toContain("Option 4 description");
+                  expect(previousCapRows.join("\n")).not.toContain("Option 4 description");
+
+                  expect((component as any).promptMaxScrollOffset).toBeGreaterThan(0);
+                  component.handleInput("end");
+                  scrolledOutput = component.render(80);
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+      expect(initialOutput.length).toBeLessThanOrEqual(
+         Math.min(terminalRows - 2, Math.max(8, Math.floor(terminalRows * 0.85))),
+      );
+      expect(scrolledOutput.join("\n")).toContain("Prompt context line 30");
+      expect(scrolledOutput.length).toBeLessThanOrEqual(
+         Math.min(terminalRows - 2, Math.max(8, Math.floor(terminalRows * 0.85))),
+      );
+   });
+
+   test("wraps long multi-select titles and narrow descriptions in inline mode", async () => {
+      const tool = await setupTool();
+      let rendered: string[] = [];
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            options: [{
+               title: "An authored title that must wrap",
+               description: "narrow description remains readable",
+            }],
+            allowMultiple: true,
+            displayMode: "inline",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  rendered = component.render(18);
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+      const compact = rendered.join("\n").replace(/[\s│]/g, "");
+      expect(compact).toContain("Anauthoredtitlethatmustwrap");
+      expect(compact).toContain("narrowdescriptionremainsreadable");
+   });
+
+   test("keeps a focused select control visible in 5- and 6-row overlays", async () => {
+      const tool = await setupTool();
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            context: "Prompt context that would otherwise consume the tiny viewport.",
+            options: ["Alpha", "Beta"],
+            allowMultiple: true,
+            allowComment: true,
+            allowFreeform: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const tui = { requestRender() { }, terminal: { rows: 24 } };
+                  const component = factory(tui, createTheme(), createKeybindings(), () => { });
+                  for (const rows of [5, 6]) {
+                     tui.terminal.rows = rows;
+                     const output = component.render(40);
+                     const compact = output.join("\n").replace(/[\s│]/g, "");
+                     expect(compact).toContain("→1.[]Alpha");
+                     expect(output.length).toBeLessThanOrEqual(rows === 5 ? 3 : 4);
+                  }
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+   });
+
+   test("keeps focused single-select options visible in 5- and 6-row overlays", async () => {
+      const tool = await setupTool();
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            context: "Prompt context that would otherwise consume the tiny viewport.",
+            options: ["Alpha", "Beta"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const tui = { requestRender() { }, terminal: { rows: 24 } };
+                  const component = factory(tui, createTheme(), createKeybindings(), () => { });
+
+                  for (const rows of [5, 6]) {
+                     tui.terminal.rows = rows;
+                     const output = component.render(40);
+                     const compact = output.join("\n").replace(/[\s│]/g, "");
+                     expect(compact).toContain("→1.Alpha");
+                     expect(output.length).toBeLessThanOrEqual(rows === 5 ? 3 : 4);
+                  }
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
    });
 
    test("keeps single-select search usable when comment toggling is enabled", async () => {

--- a/index.ts
+++ b/index.ts
@@ -30,7 +30,11 @@ import {
    truncateToWidth,
    wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { renderSingleSelectRows, type QuestionOption } from "./single-select-layout";
+import {
+   getCenteredBlockWindow,
+   renderSingleSelectRows,
+   type QuestionOption,
+} from "./single-select-layout";
 
 import { createRequire } from "node:module";
 const _require = createRequire(import.meta.url);
@@ -463,6 +467,9 @@ class MultiSelectList implements Component {
    private selectedIndex = 0;
    private checked = new Set<number>();
    private commentEnabled = false;
+   // Inline mode retains its historical ten-item window. Overlay mode sets
+   // this to the compositor-provided row budget on every render.
+   private maxVisibleRows?: number;
    private cachedWidth?: number;
    private cachedLines?: string[];
 
@@ -488,6 +495,14 @@ class MultiSelectList implements Component {
 
    public isCommentEnabled(): boolean {
       return this.commentEnabled;
+   }
+
+   setMaxVisibleRows(rows: number): void {
+      const next = Math.max(1, Math.floor(rows));
+      if (next !== this.maxVisibleRows) {
+         this.maxVisibleRows = next;
+         this.invalidate();
+      }
    }
 
    invalidate(): void {
@@ -605,6 +620,87 @@ class MultiSelectList implements Component {
       }
    }
 
+   private wrapBlockText(
+      text: string,
+      width: number,
+      firstPrefix: string,
+      continuationPrefix: string,
+      style: (line: string) => string,
+      firstPrefixWidth = firstPrefix.length,
+   ): string[] {
+      const firstWidth = Math.max(1, width - firstPrefixWidth);
+      const wrapped = wrapTextWithAnsi(text, firstWidth);
+      const lines = wrapped.length > 0 ? wrapped : [""];
+      return lines.map((line, index) => truncateToWidth(
+         `${index === 0 ? firstPrefix : continuationPrefix}${style(line)}`,
+         width,
+         "",
+      ));
+   }
+
+   private buildItemBlocks(width: number): Array<{ itemIndex: number; lines: string[] }> {
+      const theme = this.theme;
+      const count = this.getItemCount();
+      const blocks: Array<{ itemIndex: number; lines: string[] }> = [];
+
+      for (let i = 0; i < count; i++) {
+         const isSelected = i === this.selectedIndex;
+         const prefix = isSelected ? theme.fg("accent", "→") : " ";
+         const lines: string[] = [];
+
+         if (this.isCommentToggleRow(i)) {
+            const checkbox = this.commentEnabled ? theme.fg("success", "[✓]") : theme.fg("dim", "[ ]");
+            const firstPrefix = `${prefix}   ${checkbox} `;
+            const continuationPrefix = " ".repeat(8);
+            const labelStyle = isSelected
+               ? (line: string) => theme.fg("accent", theme.bold(line))
+               : (line: string) => theme.fg("text", theme.bold(line));
+            lines.push(...this.wrapBlockText(COMMENT_TOGGLE_LABEL, width, firstPrefix, continuationPrefix, labelStyle, 8));
+         } else if (this.isFreeformRow(i)) {
+            const firstPrefix = `${prefix}   `;
+            const continuationPrefix = " ".repeat(4);
+            lines.push(...this.wrapBlockText(
+               "Type something. — Enter a custom response",
+               width,
+               firstPrefix,
+               continuationPrefix,
+               (line) => theme.fg("text", theme.bold(line)),
+               4,
+            ));
+         } else {
+            const option = this.options[i];
+            if (!option) continue;
+
+            const checkbox = this.checked.has(i) ? theme.fg("success", "[✓]") : theme.fg("dim", "[ ]");
+            const num = theme.fg("dim", `${i + 1}.`);
+            const titlePrefix = `${prefix} ${num} ${checkbox} `;
+            const titlePrefixWidth = 1 + 1 + (String(i + 1).length + 1) + 1 + 3 + 1;
+            const titleContinuation = " ".repeat(titlePrefixWidth);
+            const titleStyle = isSelected
+               ? (line: string) => theme.fg("accent", theme.bold(line))
+               : (line: string) => theme.fg("text", theme.bold(line));
+            lines.push(...this.wrapBlockText(option.title, width, titlePrefix, titleContinuation, titleStyle, titlePrefixWidth));
+
+            if (option.description) {
+               // Keep one content column even on pathological narrow widths;
+               // the indentation yields to the available width rather than
+               // forcing a ten-column minimum that truncates every chunk.
+               const indentWidth = Math.min(6, Math.max(0, width - 1));
+               const indent = " ".repeat(indentWidth);
+               const wrapWidth = Math.max(1, width - indentWidth);
+               const wrapped = wrapTextWithAnsi(option.description, wrapWidth);
+               for (const line of wrapped) {
+                  lines.push(truncateToWidth(indent + theme.fg("muted", line), width, ""));
+               }
+            }
+         }
+
+         blocks.push({ itemIndex: i, lines });
+      }
+
+      return blocks;
+   }
+
    render(width: number): string[] {
       if (this.cachedLines && this.cachedWidth === width) {
          return this.cachedLines;
@@ -612,69 +708,58 @@ class MultiSelectList implements Component {
 
       const theme = this.theme;
       const count = this.getItemCount();
-      const maxVisible = Math.min(count, 10);
-
       if (count === 0) {
          this.cachedLines = [theme.fg("warning", "No options")];
          this.cachedWidth = width;
          return this.cachedLines;
       }
 
-      const startIndex = Math.max(0, Math.min(this.selectedIndex - Math.floor(maxVisible / 2), count - maxVisible));
-      const endIndex = Math.min(startIndex + maxVisible, count);
+      this.selectedIndex = Math.max(0, Math.min(this.selectedIndex, count - 1));
+      const blocks = this.buildItemBlocks(width);
+      const allRows = blocks.flatMap((block) => block.lines);
 
-      const lines: string[] = [];
-
-      for (let i = startIndex; i < endIndex; i++) {
-         const isSelected = i === this.selectedIndex;
-         const prefix = isSelected ? theme.fg("accent", "→") : " ";
-
-         if (this.isCommentToggleRow(i)) {
-            const checkbox = this.commentEnabled ? theme.fg("success", "[✓]") : theme.fg("dim", "[ ]");
-            const label = isSelected
-               ? theme.fg("accent", theme.bold(COMMENT_TOGGLE_LABEL))
-               : theme.fg("text", theme.bold(COMMENT_TOGGLE_LABEL));
-            lines.push(truncateToWidth(`${prefix}   ${checkbox} ${label}`, width, ""));
-            continue;
+      if (this.maxVisibleRows === undefined) {
+         const maxItems = Math.min(count, 10);
+         const startIndex = Math.max(0, Math.min(this.selectedIndex - Math.floor(maxItems / 2), count - maxItems));
+         const endIndex = Math.min(startIndex + maxItems, count);
+         const lines = blocks.slice(startIndex, endIndex).flatMap((block) => block.lines);
+         if (startIndex > 0 || endIndex < count) {
+            lines.push(theme.fg("dim", truncateToWidth(`  (${this.selectedIndex + 1}/${count})`, width, "")));
          }
-
-         if (this.isFreeformRow(i)) {
-            const label = theme.fg("text", theme.bold("Type something."));
-            const desc = theme.fg("muted", "Enter a custom response");
-            const line = `${prefix}   ${label} ${theme.fg("dim", "—")} ${desc}`;
-            lines.push(truncateToWidth(line, width, ""));
-            continue;
-         }
-
-         const option = this.options[i];
-         if (!option) continue;
-
-         const checkbox = this.checked.has(i) ? theme.fg("success", "[✓]") : theme.fg("dim", "[ ]");
-         const num = theme.fg("dim", `${i + 1}.`);
-         const title = isSelected
-            ? theme.fg("accent", theme.bold(option.title))
-            : theme.fg("text", theme.bold(option.title));
-
-         const firstLine = `${prefix} ${num} ${checkbox} ${title}`;
-         lines.push(truncateToWidth(firstLine, width, ""));
-
-         if (option.description) {
-            const indent = "      ";
-            const wrapWidth = Math.max(10, width - indent.length);
-            const wrapped = wrapTextWithAnsi(option.description, wrapWidth);
-            for (const w of wrapped) {
-               lines.push(truncateToWidth(indent + theme.fg("muted", w), width, ""));
-            }
-         }
+         this.cachedWidth = width;
+         this.cachedLines = lines;
+         return lines;
       }
 
-      if (startIndex > 0 || endIndex < count) {
-         lines.push(theme.fg("dim", truncateToWidth(`  (${this.selectedIndex + 1}/${count})`, width, "")));
+      const maxRows = Math.max(1, this.maxVisibleRows);
+      if (allRows.length <= maxRows) {
+         this.cachedWidth = width;
+         this.cachedLines = allRows;
+         return allRows;
       }
 
+      const indicator = theme.fg("dim", truncateToWidth(`  (${this.selectedIndex + 1}/${count})`, width, ""));
+      const window = getCenteredBlockWindow(blocks, this.selectedIndex, maxRows);
+      const availableRows = window.contentRows;
+      const selectedBlock = blocks[this.selectedIndex] ?? blocks[0];
+      if (!selectedBlock) return [];
+
+      // Keep a wrapped block whole whenever it fits. If the focused block is
+      // itself taller than the content budget, show its leading rows so focus
+      // remains identifiable, then keep the viewport's height stable.
+      let visibleRows = blocks.slice(window.startIndex, window.endIndex).flatMap((block) => block.lines);
+      if (selectedBlock.lines.length >= availableRows) {
+         visibleRows = visibleRows.slice(0, availableRows);
+      } else {
+         visibleRows.unshift(...Array.from({ length: window.paddingBeforeRows }, () => ""));
+         visibleRows.push(...Array.from({ length: window.paddingAfterRows }, () => ""));
+      }
+      while (visibleRows.length < availableRows) visibleRows.push("");
+      if (maxRows > 1) visibleRows.push(indicator);
+      visibleRows = visibleRows.slice(0, maxRows);
       this.cachedWidth = width;
-      this.cachedLines = lines;
-      return lines;
+      this.cachedLines = visibleRows;
+      return visibleRows;
    }
 }
 
@@ -826,10 +911,15 @@ class WrappedSingleSelectList implements Component {
    private buildListLines(width: number, filteredOptions: QuestionOption[], hideDescriptions = false): string[] {
       const lines: string[] = [];
       const count = this.getItemCount(filteredOptions);
+      // With one row available, the focused option/control is more useful than
+      // the filter header. Keep the header and search status at normal heights.
+      const compact = this.maxVisibleRows === 1;
       const searchValue = this.searchQuery ? this.theme.fg("text", this.searchQuery) : this.theme.fg("dim", "type to filter");
-      lines.push(truncateToWidth(`${this.theme.fg("accent", "Filter:")} ${searchValue}`, width, ""));
+      if (!compact) {
+         lines.push(truncateToWidth(`${this.theme.fg("accent", "Filter:")} ${searchValue}`, width, ""));
+      }
 
-      if (this.searchQuery && filteredOptions.length === 0) {
+      if (this.searchQuery && filteredOptions.length === 0 && (!compact || count === 0)) {
          lines.push(truncateToWidth(this.theme.fg("warning", "No matching options"), width, ""));
       }
 
@@ -1179,7 +1269,12 @@ class AskComponent extends Container {
       const bodyCapacity = Math.max(0, maxLines - 2);
       const promptLines = this.buildPromptLines(innerWidth);
       const helpFullLines = this.helpText.render(innerWidth);
-      const helpBudget = this.getOverlayHelpBudget(bodyCapacity, helpFullLines.length);
+      // A select row is the actionable surface. On 5/6-row terminals the
+      // body can hold only one or two lines, so sacrifice help before leaving
+      // the user with no focused control at all.
+      const helpBudget = this.mode === "select" && bodyCapacity <= 2
+         ? 0
+         : this.getOverlayHelpBudget(bodyCapacity, helpFullLines.length);
       const contentRows = Math.max(0, bodyCapacity - helpBudget);
 
       let promptBudget = 0;
@@ -1189,24 +1284,33 @@ class AskComponent extends Container {
       if (this.mode === "select") {
          separatorRows = contentRows >= 4 ? 1 : 0;
          const promptAndModeRows = Math.max(0, contentRows - separatorRows);
-         promptBudget = promptAndModeRows;
 
-         if (promptAndModeRows > 0) {
-            const promptMinRows = promptLines.length > 0 ? 1 : 0;
-            const maximumModeRows = Math.max(0, promptAndModeRows - promptMinRows);
-            const modeMinRows = Math.min(this.getMinimumModeRows(), maximumModeRows);
-            modeBudget = Math.min(this.getPreferredModeRows(), maximumModeRows);
-            modeBudget = Math.max(modeMinRows, modeBudget);
-            promptBudget = promptAndModeRows - modeBudget;
+         if (bodyCapacity <= 2) {
+            // Keep at least one focused option/control visible. Prompt and
+            // help are expendable at this size and reappear at normal heights.
+            promptBudget = 0;
+            modeBudget = promptAndModeRows;
+            separatorRows = 0;
+         } else {
+            promptBudget = promptAndModeRows;
 
-            const usefulPromptRows = Math.min(
-               promptLines.length,
-               promptAndModeRows >= modeMinRows + 2 ? 2 : promptMinRows,
-            );
-            if (promptBudget < usefulPromptRows && modeBudget > modeMinRows) {
-               const shiftedRows = Math.min(usefulPromptRows - promptBudget, modeBudget - modeMinRows);
-               modeBudget -= shiftedRows;
-               promptBudget += shiftedRows;
+            if (promptAndModeRows > 0) {
+               const promptMinRows = promptLines.length > 0 ? 1 : 0;
+               const maximumModeRows = Math.max(0, promptAndModeRows - promptMinRows);
+               const modeMinRows = Math.min(this.getMinimumModeRows(), maximumModeRows);
+               modeBudget = Math.min(this.getPreferredModeRows(), maximumModeRows);
+               modeBudget = Math.max(modeMinRows, modeBudget);
+               promptBudget = promptAndModeRows - modeBudget;
+
+               const usefulPromptRows = Math.min(
+                  promptLines.length,
+                  promptAndModeRows >= modeMinRows + 2 ? 2 : promptMinRows,
+               );
+               if (promptBudget < usefulPromptRows && modeBudget > modeMinRows) {
+                  const shiftedRows = Math.min(usefulPromptRows - promptBudget, modeBudget - modeMinRows);
+                  modeBudget -= shiftedRows;
+                  promptBudget += shiftedRows;
+               }
             }
          }
       } else {
@@ -1259,7 +1363,7 @@ class AskComponent extends Container {
    private getPreferredModeRows(): number {
       if (this.mode === "freeform") return 10;
       if (this.mode === "comment") return 11;
-      return 8;
+      return 12;
    }
 
    private renderModeLines(width: number, budget: number): string[] {
@@ -1267,9 +1371,15 @@ class AskComponent extends Container {
       if (safeBudget <= 0) return [];
 
       if (this.mode === "select") {
-         if (!this.allowMultiple) {
-            this.ensureSingleSelectList().setMaxVisibleRows(Math.max(1, safeBudget));
+         if (this.allowMultiple) {
+            this.ensureMultiSelectList().setMaxVisibleRows(Math.max(1, safeBudget));
+            // Multi-select owns its row-budget-aware viewport so variable-height
+            // descriptions and the focused control are never clipped by a
+            // generic outer ellipsis.
+            return this.modeContainer.render(width);
          }
+
+         this.ensureSingleSelectList().setMaxVisibleRows(Math.max(1, safeBudget));
          return this.limitLines(this.modeContainer.render(width), safeBudget, width, true);
       }
 

--- a/single-select-layout.test.ts
+++ b/single-select-layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { renderSingleSelectRows } from "./single-select-layout";
+import { getCenteredBlockWindow, renderSingleSelectRows } from "./single-select-layout";
 
 describe("renderSingleSelectRows", () => {
 	test("wraps long option titles instead of truncating them away", () => {
@@ -104,5 +104,96 @@ describe("renderSingleSelectRows", () => {
 			expect(row.line).not.toContain("Gamma");
 		}
 		expect(nonSelectedRows.length).toBeGreaterThan(0);
+	});
+
+	test("keeps an equal-height viewport stable until focus reaches its center", () => {
+		const options = Array.from({ length: 10 }, (_, index) => ({ title: `Option ${index + 1}` }));
+		const render = (selectedIndex: number) => renderSingleSelectRows({
+			options,
+			selectedIndex,
+			width: 40,
+			allowFreeform: false,
+			maxRows: 6,
+		}).map((row) => row.line);
+
+		const content = (selectedIndex: number) => render(selectedIndex)
+			.slice(0, -1)
+			.map((line) => line.replace("→", " "))
+			.join("\n");
+		const first = content(0);
+		expect(content(1)).toBe(first);
+		expect(content(2)).toBe(first);
+		expect(content(3)).not.toBe(first);
+		expect(content(3)).toContain("Option 6");
+		for (let selectedIndex = 0; selectedIndex < options.length; selectedIndex++) {
+			expect(render(selectedIndex)).toHaveLength(6);
+		}
+	});
+
+	test("anchors variable-height helper windows at the top and bottom boundaries", () => {
+		const blocks = [1, 1, 4, 1, 1].map((height) => ({ lines: Array.from({ length: height }) }));
+
+		expect(getCenteredBlockWindow(blocks, 1, 6)).toEqual({
+			startIndex: 0,
+			endIndex: 2,
+			contentRows: 5,
+			paddingBeforeRows: 0,
+			paddingAfterRows: 3,
+			overflow: true,
+		});
+		expect(getCenteredBlockWindow(blocks, 2, 6)).toEqual({
+			startIndex: 1,
+			endIndex: 3,
+			contentRows: 5,
+			paddingBeforeRows: 0,
+			paddingAfterRows: 0,
+			overflow: true,
+		});
+		expect(getCenteredBlockWindow(blocks, 3, 6)).toEqual({
+			startIndex: 3,
+			endIndex: 5,
+			contentRows: 5,
+			paddingBeforeRows: 3,
+			paddingAfterRows: 0,
+			overflow: true,
+		});
+	});
+
+	test("places variable-height single-select padding on the anchored edge", () => {
+		const options = [
+			{ title: "Option 1" },
+			{ title: "Option 2" },
+			{ title: "aaaaaaaa bbbbbbbb cccccccc dddddddd" },
+			{ title: "Option 4" },
+			{ title: "Option 5" },
+		];
+		const render = (selectedIndex: number) => renderSingleSelectRows({
+			options,
+			selectedIndex,
+			width: 12,
+			allowFreeform: false,
+			maxRows: 6,
+		});
+
+		const early = render(1);
+		expect(early).toHaveLength(6);
+		expect(early[0]?.line).toContain("Option 1");
+		expect(early[1]).toMatchObject({ selected: true });
+		expect(early[1]?.line).toContain("Option 2");
+		expect(early.slice(2, 5).map((row) => row.line)).toEqual(["", "", ""]);
+		expect(early[5]?.line).toBe("  (2/5)");
+
+		const middle = render(2);
+		expect(middle).toHaveLength(6);
+		expect(middle.filter((row) => row.selected)).toHaveLength(4);
+		expect(middle.slice(0, 5).map((row) => row.line).join(" ")).toContain("dddddddd");
+
+		const late = render(3);
+		expect(late).toHaveLength(6);
+		expect(late.slice(0, 3).map((row) => row.line)).toEqual(["", "", ""]);
+		expect(late[3]).toMatchObject({ selected: true });
+		expect(late[3]?.line).toContain("Option 4");
+		expect(late[4]?.line).toContain("Option 5");
+		expect(late[5]?.line).toBe("  (4/5)");
 	});
 });

--- a/single-select-layout.ts
+++ b/single-select-layout.ts
@@ -8,6 +8,149 @@ export interface AnnotatedRow {
 	selected: boolean;
 }
 
+export interface CenteredBlockWindow {
+	startIndex: number;
+	endIndex: number;
+	contentRows: number;
+	paddingBeforeRows: number;
+	paddingAfterRows: number;
+	/** True when the returned window is a viewport over overflowing content. */
+	overflow: boolean;
+}
+
+/**
+ * Pick a contiguous, block-aligned window around the focused item. Blocks are
+ * kept whole whenever they fit; an oversized focused block is handled by the
+ * caller by clipping its rows to `contentRows`.
+ *
+ * The final row of an overflowing viewport is reserved for the position
+ * indicator, matching the select-list rendering in both modes.
+ */
+export function getCenteredBlockWindow(
+	blocks: ReadonlyArray<{ lines: readonly unknown[] }>,
+	selectedIndex: number,
+	maxRows: number,
+): CenteredBlockWindow {
+	const safeMaxRows = Math.max(1, Math.floor(maxRows));
+	const totalRows = blocks.reduce((sum, block) => sum + block.lines.length, 0);
+	if (totalRows <= safeMaxRows) {
+		return {
+			startIndex: 0,
+			endIndex: blocks.length,
+			contentRows: totalRows,
+			paddingBeforeRows: 0,
+			paddingAfterRows: 0,
+			overflow: false,
+		};
+	}
+
+	const contentRows = safeMaxRows > 1 ? safeMaxRows - 1 : 1;
+	if (blocks.length === 0) {
+		return {
+			startIndex: 0,
+			endIndex: 0,
+			contentRows,
+			paddingBeforeRows: 0,
+			paddingAfterRows: contentRows,
+			overflow: true,
+		};
+	}
+
+	const focusedIndex = Math.max(0, Math.min(selectedIndex, blocks.length - 1));
+	const focusedRows = blocks[focusedIndex]?.lines.length ?? 0;
+	if (focusedRows >= contentRows) {
+		return {
+			startIndex: focusedIndex,
+			endIndex: focusedIndex + 1,
+			contentRows,
+			paddingBeforeRows: 0,
+			paddingAfterRows: 0,
+			overflow: true,
+		};
+	}
+
+	const rowPrefix = [0];
+	for (const block of blocks) rowPrefix.push(rowPrefix[rowPrefix.length - 1]! + block.lines.length);
+	const viewportCenter = contentRows / 2;
+	const focusedCenter = rowPrefix[focusedIndex]! + focusedRows / 2;
+
+	// At the top and bottom boundaries, preserving the edge anchor takes
+	// precedence over filling every content row. This prevents a tall adjacent
+	// block from moving focus past the viewport midpoint prematurely.
+	if (focusedCenter <= viewportCenter) {
+		let endIndex = 0;
+		while (endIndex < blocks.length && rowPrefix[endIndex + 1]! <= contentRows) endIndex++;
+		const usedRows = rowPrefix[endIndex]!;
+		return {
+			startIndex: 0,
+			endIndex,
+			contentRows,
+			paddingBeforeRows: 0,
+			paddingAfterRows: contentRows - usedRows,
+			overflow: true,
+		};
+	}
+
+	if (focusedCenter >= totalRows - viewportCenter) {
+		let startIndex = blocks.length;
+		while (startIndex > 0 && totalRows - rowPrefix[startIndex - 1]! <= contentRows) startIndex--;
+		const usedRows = totalRows - rowPrefix[startIndex]!;
+		return {
+			startIndex,
+			endIndex: blocks.length,
+			contentRows,
+			paddingBeforeRows: contentRows - usedRows,
+			paddingAfterRows: 0,
+			overflow: true,
+		};
+	}
+
+	type Candidate = {
+		startIndex: number;
+		endIndex: number;
+		usedRows: number;
+		paddingBeforeRows: number;
+		distance: number;
+	};
+	let best: Candidate | undefined;
+
+	// In the middle, choose a conventional centered, contiguous full-block
+	// window. Unavoidable slack participates in centering before occupied-row
+	// count, so variable-height neighbors cannot pull focus off its anchor.
+	for (let startIndex = 0; startIndex <= focusedIndex; startIndex++) {
+		for (let endIndex = focusedIndex + 1; endIndex <= blocks.length; endIndex++) {
+			const usedRows = rowPrefix[endIndex]! - rowPrefix[startIndex]!;
+			if (usedRows > contentRows) break;
+
+			const slack = contentRows - usedRows;
+			const focusedCenterInWindow = rowPrefix[focusedIndex]! - rowPrefix[startIndex]! + focusedRows / 2;
+			const idealPadding = viewportCenter - focusedCenterInWindow;
+			const paddingBeforeRows = Math.max(0, Math.min(slack, Math.round(idealPadding)));
+			const distance = Math.abs(focusedCenterInWindow + paddingBeforeRows - viewportCenter);
+			if (
+				!best ||
+				distance < best.distance - Number.EPSILON ||
+				(Math.abs(distance - best.distance) <= Number.EPSILON && usedRows > best.usedRows) ||
+				(Math.abs(distance - best.distance) <= Number.EPSILON &&
+					usedRows === best.usedRows && startIndex < best.startIndex)
+			) {
+				best = { startIndex, endIndex, usedRows, paddingBeforeRows, distance };
+			}
+		}
+	}
+
+	const usedRows = best?.usedRows ?? focusedRows;
+	const paddingBeforeRows = best?.paddingBeforeRows ?? 0;
+	return {
+		startIndex: best?.startIndex ?? focusedIndex,
+		endIndex: best?.endIndex ?? focusedIndex + 1,
+		contentRows,
+		paddingBeforeRows,
+		paddingAfterRows: contentRows - usedRows - paddingBeforeRows,
+		overflow: true,
+	};
+}
+
 export interface RenderSingleSelectRowsParams {
 	options: QuestionOption[];
 	selectedIndex: number;
@@ -159,45 +302,22 @@ export function renderSingleSelectRows({
 		return allRows;
 	}
 
+	const window = getCenteredBlockWindow(blocks, selectedIndex, maxRows);
 	const safeMaxRows = Math.max(1, Math.floor(maxRows));
+	const availableRows = window.contentRows;
 	const selectedBlock = blocks[selectedIndex] ?? blocks[0];
 	if (!selectedBlock) return [];
 
-	const indicator = `  (${selectedIndex + 1}/${itemCount})`;
-	const availableRows = safeMaxRows > 1 ? safeMaxRows - 1 : 1;
-
+	const visible = flatten(blocks.slice(window.startIndex, window.endIndex), selectedIndex);
 	if (selectedBlock.lines.length >= availableRows) {
-		const visible = selectedBlock.lines.slice(0, availableRows).map((line) => ({
-			line,
-			selected: true,
-		}));
-		if (safeMaxRows > 1) visible.push({ line: indicator, selected: false });
-		return visible.slice(0, safeMaxRows);
+		// An individual wrapped block can be taller than the pane. Keep the
+		// focused block identifiable while reserving the indicator row.
+		visible.splice(availableRows);
+	} else {
+		visible.unshift(...Array.from({ length: window.paddingBeforeRows }, () => ({ line: "", selected: false })));
+		visible.push(...Array.from({ length: window.paddingAfterRows }, () => ({ line: "", selected: false })));
 	}
-
-	let start = selectedIndex;
-	let end = selectedIndex + 1;
-	let usedRows = selectedBlock.lines.length;
-
-	while (true) {
-		const nextCanFit = end < blocks.length && usedRows + blocks[end]!.lines.length <= availableRows;
-		if (nextCanFit) {
-			usedRows += blocks[end]!.lines.length;
-			end += 1;
-			continue;
-		}
-
-		const prevCanFit = start > 0 && usedRows + blocks[start - 1]!.lines.length <= availableRows;
-		if (prevCanFit) {
-			start -= 1;
-			usedRows += blocks[start]!.lines.length;
-			continue;
-		}
-
-		break;
-	}
-
-	const visible = flatten(blocks.slice(start, end), selectedIndex);
-	visible.push({ line: indicator, selected: false });
+	while (visible.length < availableRows) visible.push({ line: "", selected: false });
+	if (safeMaxRows > 1) visible.push({ line: `  (${selectedIndex + 1}/${itemCount})`, selected: false });
 	return visible.slice(0, safeMaxRows);
 }


### PR DESCRIPTION
## Summary

- make multi-select overlays consume the compositor's row budget instead of being clipped by the outer ellipsis
- keep focused options, freeform input, and optional-comment controls visibly reachable while navigating and after terminal resizes
- use a stable variable-height viewport with top anchoring, centered scrolling, bottom anchoring, and position indicators
- wrap long option titles, descriptions, and control labels without breaking narrow or tiny terminals
- increase the preferred select pane from 8 to 12 rows when terminal space permits
- apply the shared scrolling behavior to single-select lists while preserving their wide details pane, filtering, inline mode, selection state, and keyboard behavior

Closes #33.

## Validation

- `pnpm dlx bun test` — 79 passed
- `npm run check`
- `git diff --check upstream/main...HEAD`
- independent review plus exhaustive generated-height validation across 1,017,680 viewport combinations

## Manual testing

Validated interactively with:

- a long context block
- 10 described multi-select options
- freeform and optional-comment controls
- navigation across top, middle, and bottom viewport boundaries
- terminal shrinking and growing while focus was on late controls
- wide single-select mode with its Markdown details pane
- overlay and inline display modes
