### PR TITLE
Add responsive prompts and host lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Responsive context collapse for overlay and inline prompts; oversized context preserves the full value while keeping the question and choices visible, and `ctrl+e` toggles the expanded view.
+
 ## [0.13.1](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.1) - 2026-08-01
 
 ### Fixed
 
 - Multi-select overlay prompts no longer scroll the underlying terminal when the option list exceeds the visible area; scrolling is now contained inside the overlay. Closes #33. (#35)
-
 ## [0.13.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.0) - 2026-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@
 ### Added
 
 - Responsive context collapse for overlay and inline prompts; oversized context preserves the full value while keeping the question and choices visible, and `ctrl+e` toggles the expanded view.
+- Configurable `auto` or always-single-column layouts for wide single-select prompts. Closes #30.
+- `herdr:blocked` lifecycle events while waiting for structured or freeform user input.
 
 ## [0.13.1](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.1) - 2026-08-01
 
 ### Fixed
 
 - Multi-select overlay prompts no longer scroll the underlying terminal when the option list exceeds the visible area; scrolling is now contained inside the overlay. Closes #33. (#35)
+
 ## [0.13.0](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.0) - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ While an `ask_user` prompt is open:
 |-----|--------|
 | `alt+o` (configurable via `overlayToggleKey`) | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you which key brings it back. |
 | `ctrl+g` (configurable via `commentToggleKey`) | Toggle the optional comment/extra-context row (when `allowComment: true`). |
-| `ctrl+e` | Expand or collapse oversized context while choosing an option. |
+| `ctrl+e` | Expand or collapse oversized context while choosing an option. If another configured ask shortcut owns it, the prompt shows `ctrl+x` or `ctrl+y` instead. |
 | `enter` | Confirm the focused option, submit a freeform response, or submit/skip an optional comment. |
 | `esc` | Clear the search filter, exit freeform/comment mode, or cancel the prompt. |
 | `↑` / `↓`, `ctrl+k` / `ctrl+j` | Navigate options. `ctrl+k` / `ctrl+j` (vim-style) work while typing in searchable prompts without disturbing the filter. |
@@ -148,7 +148,7 @@ If you prefer never to see the overlay, set `displayMode: "inline"` per call or 
 
 ### Mobile-sized terminals
 
-The bundled skill asks models to keep questions and decision context concise. If context still wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press `ctrl+e` to expand or collapse the complete context; expanded context remains scrollable with the existing prompt-scroll keys.
+The bundled skill asks models to keep questions and decision context concise. If context still wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press the context key shown in the prompt (`ctrl+e` by default) to expand or collapse the complete context; expanded context remains bounded and scrollable with the existing prompt-scroll keys in both display modes.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ High-quality video: [ask-user-demo.mp4](./media/ask-user-demo.mp4)
 - Optional freeform responses
 - User-toggleable extra context on structured selections
 - Context display support
+- Mobile-first question guidance plus responsive context collapse that keeps the question and choices visible on small terminals without discarding full context
 - Configurable display mode: `overlay` (modal, default) or `inline` (rendered directly in the flow)
 - Runtime overlay toggle: press the configured overlay-toggle key (`alt+o` by default, configurable per call or via env var) while the prompt is open to temporarily hide/show the popup so you can read prior agent output, then press it again to bring it back
 - Pi-TUI-aligned keybinding and editor behavior
@@ -138,11 +139,16 @@ While an `ask_user` prompt is open:
 |-----|--------|
 | `alt+o` (configurable via `overlayToggleKey`) | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you which key brings it back. |
 | `ctrl+g` (configurable via `commentToggleKey`) | Toggle the optional comment/extra-context row (when `allowComment: true`). |
+| `ctrl+e` | Expand or collapse oversized context while choosing an option. |
 | `enter` | Confirm the focused option, submit a freeform response, or submit/skip an optional comment. |
 | `esc` | Clear the search filter, exit freeform/comment mode, or cancel the prompt. |
 | `↑` / `↓`, `ctrl+k` / `ctrl+j` | Navigate options. `ctrl+k` / `ctrl+j` (vim-style) work while typing in searchable prompts without disturbing the filter. |
 
 If you prefer never to see the overlay, set `displayMode: "inline"` per call or `PI_ASK_USER_DISPLAY_MODE=inline` globally.
+
+### Mobile-sized terminals
+
+The bundled skill asks models to keep questions and decision context concise. If context still wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press `ctrl+e` to expand or collapse the complete context; expanded context remains scrollable with the existing prompt-scroll keys.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ High-quality video: [ask-user-demo.mp4](./media/ask-user-demo.mp4)
 ## Features
 
 - Searchable single-select option lists with wrapped titles and descriptions
-- Responsive split-pane details preview on wide terminals with single-column fallback on narrow terminals
+- Responsive split-pane details preview on wide terminals, with a persistent single-column preference
 - Multi-select option lists
 - Optional freeform responses
 - User-toggleable extra context on structured selections
 - Context display support
-- Mobile-first question guidance plus responsive context collapse that keeps the question and choices visible on small terminals without discarding full context
+- Responsive context collapse that keeps the question and choices visible on small terminals without discarding full context
 - Configurable display mode: `overlay` (modal, default) or `inline` (rendered directly in the flow)
 - Runtime overlay toggle: press the configured overlay-toggle key (`alt+o` by default, configurable per call or via env var) while the prompt is open to temporarily hide/show the popup so you can read prior agent output, then press it again to bring it back
 - Pi-TUI-aligned keybinding and editor behavior
 - Custom TUI rendering for tool calls and results
 - System prompt integration via `promptSnippet` and `promptGuidelines`
 - Optional timeout for auto-dismiss in both overlay and fallback input modes
+- `herdr:blocked` lifecycle events while waiting for interactive input
 - Structured `details` on all results for session state reconstruction
 - Graceful fallback when interactive UI is unavailable
 - Bundled `ask-user` skill for mandatory decision-gating in high-stakes or ambiguous tasks
@@ -67,6 +68,7 @@ The registered tool name is:
 | `allowFreeform` | `boolean?` | `true` | Add a "Type something" freeform option |
 | `allowComment` | `boolean?` | env var or `false` | Expose a user-toggleable extra-context option in the custom UI (`ctrl+g` or the toggle row) and collect an optional comment in fallback dialogs |
 | `displayMode` | `"overlay" \| "inline"?` | env var or `"overlay"` | Controls custom UI rendering: `overlay` shows the centered modal (current behavior), `inline` renders without overlay framing |
+| `singleSelectLayout` | `"auto" \| "list"?` | env var or `"auto"` | Use the responsive details pane automatically or always render descriptions below their options |
 | `overlayToggleKey` | `string?` | env var or `"alt+o"` | Shortcut for hiding/showing the overlay popup (overlay mode only). Pi-TUI key spec, e.g. `"alt+o"`, `"ctrl+shift+h"`. Pass `"off"` to disable. |
 | `commentToggleKey` | `string?` | env var or `"ctrl+g"` | Shortcut for toggling the optional comment/extra-context row when `allowComment: true`. Pass `"off"` to disable. |
 | `timeout` | `number?` | — | Auto-dismiss after N ms and return `null` if the prompt times out |
@@ -96,6 +98,7 @@ Configure your defaults globally by setting these in your shell profile (`~/.zsh
 
 ```bash
 export PI_ASK_USER_DISPLAY_MODE=inline
+export PI_ASK_USER_SINGLE_SELECT_LAYOUT=list
 export PI_ASK_USER_ALLOW_COMMENT=true
 export PI_ASK_USER_OVERLAY_TOGGLE_KEY=alt+h
 export PI_ASK_USER_COMMENT_TOGGLE_KEY=alt+c
@@ -112,6 +115,16 @@ Effective order:
 3. Fallback default: `"overlay"`
 
 Unrecognised values are silently ignored and fall back to `"overlay"`.
+
+### Single-select layout
+
+Effective order:
+
+1. Per-call `singleSelectLayout` parameter (if provided)
+2. `PI_ASK_USER_SINGLE_SELECT_LAYOUT` (when set to `list`)
+3. Fallback default: `auto`
+
+`auto` shows the details pane on wide terminals. `list` keeps descriptions below their options at every width.
 
 ### Optional comments
 
@@ -148,7 +161,11 @@ If you prefer never to see the overlay, set `displayMode: "inline"` per call or 
 
 ### Mobile-sized terminals
 
-The bundled skill asks models to keep questions and decision context concise. If context still wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press the context key shown in the prompt (`ctrl+e` by default) to expand or collapse the complete context; expanded context remains bounded and scrollable with the existing prompt-scroll keys in both display modes.
+If context wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press the context key shown in the prompt (`ctrl+e` by default) to expand or collapse the complete context; expanded context remains bounded and scrollable with the existing prompt-scroll keys in both display modes.
+
+### Waiting lifecycle event
+
+While an interactive prompt is open, the extension emits `herdr:blocked` with `{ active: true, label: "Waiting for user response" }`. It emits `{ active: false }` in `finally`, including cancellation and error paths. Hosts without a listener are unaffected.
 
 ## Known limitations
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1675,7 +1675,7 @@ describe("ask_user", () => {
       const joined = rendered.join("\n").replace(/\s+/g, " ");
       expect(joined).toContain("Which deployment strategy should we");
       expect(joined).toContain("use?");
-      expect(joined).toContain("Alpha");
+      expect(joined).toContain("→ 1. Alpha");
       expect(joined).toContain("Context (");
       expect(joined).toContain("ctrl+e");
       expect(joined).not.toContain("Decision-critical context detail.");
@@ -1993,6 +1993,50 @@ describe("ask_user", () => {
       expect(longOutput).not.toContain("Long context detail.");
    });
 
+   test("keeps medium inline context expanded until the user collapses it", async () => {
+      const tool = await setupTool();
+      let firstExpanded = "";
+      let secondExpanded = "";
+      let collapsedAgain = "";
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: Array.from({ length: 6 }, (_, index) => `Medium context line ${index}`).join("\n"),
+            options: ["Alpha", "Beta"],
+            displayMode: "inline",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(60);
+                  component.handleInput("ctrl+e");
+                  firstExpanded = component.render(60).join("\n");
+                  secondExpanded = component.render(60).join("\n");
+                  component.handleInput("ctrl+e");
+                  collapsedAgain = component.render(60).join("\n");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(firstExpanded).toContain("Medium context line 5");
+      expect(secondExpanded).toContain("Medium context line 5");
+      expect(collapsedAgain).toContain("Context (");
+      expect(collapsedAgain).not.toContain("Medium context line 5");
+   });
+
    test("bounds and scrolls expanded context in inline mode", async () => {
       const tool = await setupTool();
       let expanded: string[] = [];
@@ -2080,6 +2124,47 @@ describe("ask_user", () => {
       expect(help).toContain("ctrl+e toggle context");
       expect(help).toContain("ctrl+x expand context");
       expect(commentEnabled).toBe(true);
+      expect(expanded).toContain("Long context detail.");
+   });
+
+   test("moves the context toggle when the overlay shortcut owns ctrl+e", async () => {
+      const tool = await setupTool();
+      let help = "";
+      let expanded = "";
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: "Long context detail. ".repeat(80),
+            options: ["Alpha", "Beta"],
+            overlayToggleKey: "ctrl+e",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 12 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(50);
+                  help = (component as any).helpText.render(120).join("\n");
+                  component.handleInput("ctrl+x");
+                  component.render(50);
+                  component.handleInput("end");
+                  expanded = component.render(50).join("\n");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(help).toContain("ctrl+x expand context");
       expect(expanded).toContain("Long context detail.");
    });
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1639,15 +1639,58 @@ describe("ask_user", () => {
       expect(rendered).toContain("The alpha option keeps the rollout conservative.");
    });
 
-   test("keeps the top prompt, answers, and help visible when a long overlay prompt overflows", async () => {
+   test.each([
+      { width: 40, rows: 12 },
+      { width: 60, rows: 20 },
+   ])("keeps the question, collapsed context, and a choice visible at $width x $rows", async ({ width, rows }) => {
       const tool = await setupTool();
       let rendered: string[] = [];
-      let capturedOptions: any;
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which deployment strategy should we use?",
+            context: "Decision-critical context detail. ".repeat(80),
+            options: ["Alpha", "Beta"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  rendered = component.render(width);
+                  return null;
+               },
+            },
+         },
+      );
+
+      const joined = rendered.join("\n").replace(/\s+/g, " ");
+      expect(joined).toContain("Which deployment strategy should we");
+      expect(joined).toContain("use?");
+      expect(joined).toContain("Alpha");
+      expect(joined).toContain("Context (");
+      expect(joined).toContain("ctrl+e");
+      expect(joined).not.toContain("Decision-critical context detail.");
+   });
+
+   test("expands and re-collapses long context without losing filtered selection", async () => {
+      const tool = await setupTool();
+      let collapsed = "";
+      let expanded = "";
+      let recollapsed = "";
 
       const result = await tool.execute(
          "tool-call-id",
          {
-            question: "This is a very long question. ".repeat(80),
+            question: "Which option should we use?",
             context: "Context detail. ".repeat(80),
             options: ["Alpha", "Beta"],
          },
@@ -1656,30 +1699,35 @@ describe("ask_user", () => {
          {
             hasUI: true,
             ui: {
-               custom: async (factory: any, options: any) => {
-                  capturedOptions = options;
+               custom: async (factory: any) => {
+                  let resolved: unknown;
                   const component = factory(
                      { requestRender() { }, terminal: { rows: 12 } },
                      createTheme(),
                      createKeybindings(),
-                     () => { },
+                     (value: unknown) => { resolved = value; },
                   );
-                  rendered = component.render(50);
-                  return null;
+                  component.handleInput("b");
+                  collapsed = component.render(50).join("\n");
+                  component.handleInput("ctrl+e");
+                  component.render(50);
+                  component.handleInput("end");
+                  expanded = component.render(50).join("\n");
+                  component.handleInput("ctrl+e");
+                  recollapsed = component.render(50).join("\n");
+                  component.handleInput("enter");
+                  return resolved ?? null;
                },
             },
          },
       );
 
-      const joined = rendered.join("\n");
-      expect(result.isError).not.toBe(true);
-      expect(capturedOptions.overlay).toBe(true);
-      expect(rendered.length).toBeLessThanOrEqual(10);
-      expect(joined).toContain("Question");
-      expect(joined).toContain("This is a very long question.");
-      expect(joined).toContain("Alpha");
-      expect(joined).toContain("PgUp/PgDn prompt");
-      expect(joined).toContain("↓");
+      expect(collapsed).toContain("Context (");
+      expect(expanded).toContain("Context detail.");
+      expect(expanded).toContain("Beta");
+      expect(recollapsed).not.toContain("Context detail.");
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["Beta"] });
+      expect(result.details.context).toContain("Context detail.");
    });
 
    test("scrolls constrained multi-select overlays to the comment and freeform rows", async () => {
@@ -1760,6 +1808,8 @@ describe("ask_user", () => {
                      () => { },
                   );
                   initialRendered = component.render(50);
+                  component.handleInput("ctrl+e");
+                  component.render(50);
                   component.handleInput("end");
                   scrolledRendered = component.render(50);
                   component.handleInput("home");
@@ -1774,7 +1824,8 @@ describe("ask_user", () => {
       expect(initialRendered.join("\n")).toContain("Question line 0");
       expect(scrolledRendered.join("\n")).toContain("Context line 7");
       expect(scrolledRendered.join("\n")).toContain("Alpha");
-      expect(scrolledRendered.join("\n")).toContain("PgUp/PgDn prompt");
+      expect(scrolledRendered.join("\n")).toContain("ctrl+e collapse context");
+      expect(scrolledRendered.join("\n")).toContain("PgUp/P");
       expect(restoredRendered.join("\n")).toContain("Question line 0");
    });
 
@@ -1904,6 +1955,42 @@ describe("ask_user", () => {
 
       expect(result.isError).not.toBe(true);
       expect(rendered.length).toBeGreaterThan(10);
+   });
+
+   test("collapses oversized context in inline mode but leaves short context expanded", async () => {
+      const tool = await setupTool();
+      const render = async (context: string) => {
+         let output = "";
+         await tool.execute(
+            "tool-call-id",
+            { question: "Pick one", context, options: ["Alpha", "Beta"], displayMode: "inline" },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (factory: any) => {
+                     const component = factory(
+                        { requestRender() { }, terminal: { rows: 12 } },
+                        createTheme(),
+                        createKeybindings(),
+                        () => { },
+                     );
+                     output = component.render(40).join("\n");
+                     return null;
+                  },
+               },
+            },
+         );
+         return output;
+      };
+
+      const shortOutput = await render("Short context.");
+      const longOutput = await render("Long context detail. ".repeat(80));
+      expect(shortOutput).toContain("Short context.");
+      expect(shortOutput).not.toContain("Context (");
+      expect(longOutput).toContain("Context (");
+      expect(longOutput).not.toContain("Long context detail.");
    });
 
    test("submits immediately when the comment toggle is off", async () => {

--- a/index.test.ts
+++ b/index.test.ts
@@ -248,6 +248,23 @@ function createTheme() {
    };
 }
 
+function renderSingleSelectFromFactory(factory: unknown, width = 120): string {
+   // The custom UI callback is untyped in the test harness; narrow only the surface exercised here.
+   const createComponent = factory as unknown as (
+      tui: unknown,
+      theme: unknown,
+      keybindings: unknown,
+      done: () => void,
+   ) => { singleSelectList: { render: (renderWidth: number) => string[] } };
+   const component = createComponent(
+      { requestRender() { }, terminal: { rows: 24 } },
+      createTheme(),
+      createKeybindings(),
+      () => { },
+   );
+   return component.singleSelectList.render(width).join("\n");
+}
+
 describe("ask_user", () => {
    test("registers with executionMode 'sequential' so the agent loop awaits the user's answer before other tool calls run", async () => {
       const tool = await setupTool();
@@ -1562,6 +1579,70 @@ describe("ask_user", () => {
       expect(result.isError).not.toBe(true);
       expect(rendered).toContain("## Alpha");
       expect(rendered).toContain("The alpha option keeps the rollout conservative.");
+   });
+
+   test("keeps wide single-select prompts in one column when requested", async () => {
+      const tool = await setupTool();
+      let rendered = "";
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: [
+               { title: "Alpha", description: "The alpha option stays below its title." },
+               { title: "Beta", description: "The beta option stays below its title." },
+            ],
+            singleSelectLayout: "list",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: unknown) => {
+                  rendered = renderSingleSelectFromFactory(factory);
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(result.isError).not.toBe(true);
+      expect(rendered).toContain("The alpha option stays below its title.");
+      expect(rendered).not.toContain("## Alpha");
+      expect(rendered).not.toContain(" │ ");
+   });
+
+   test("uses PI_ASK_USER_SINGLE_SELECT_LAYOUT unless the call overrides it", async () => {
+      stubEnv("PI_ASK_USER_SINGLE_SELECT_LAYOUT", "list");
+      const tool = await setupTool();
+      const render = async (singleSelectLayout?: "auto") => {
+         let output = "";
+         await tool.execute(
+            "tool-call-id",
+            {
+               question: "Which option should we use?",
+               options: [{ title: "Alpha", description: "Alpha details." }],
+               singleSelectLayout,
+            },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (factory: unknown) => {
+                     output = renderSingleSelectFromFactory(factory);
+                     return null;
+                  },
+               },
+            },
+         );
+         return output;
+      };
+
+      expect(await render()).not.toContain("## Alpha");
+      expect(await render("auto")).toContain("## Alpha");
    });
 
    test("shows a custom response preview in the wide details pane", async () => {

--- a/index.test.ts
+++ b/index.test.ts
@@ -254,6 +254,43 @@ describe("ask_user", () => {
       expect((tool as any).executionMode).toBe("sequential");
    });
 
+   test("emits Herdr blocked lifecycle while awaiting a structured answer", async () => {
+      const tool = await setupTool();
+
+      await tool.execute(
+         "tool-call-id",
+         { question: "Continue?", options: ["Yes"] },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: { custom: async () => ({ kind: "selection", selections: ["Yes"] }) },
+         },
+      );
+
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
+   test("emits Herdr blocked lifecycle while awaiting a freeform answer", async () => {
+      const tool = await setupTool();
+
+      await tool.execute(
+         "tool-call-id",
+         { question: "Why?", options: [] },
+         undefined,
+         undefined,
+         { hasUI: true, ui: { input: async () => "Because" } },
+      );
+
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
    test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;

--- a/index.test.ts
+++ b/index.test.ts
@@ -291,6 +291,42 @@ describe("ask_user", () => {
       ]);
    });
 
+   test("clears Herdr blocked lifecycle when structured UI rejects", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         { question: "Continue?", options: ["Yes"] },
+         undefined,
+         undefined,
+         { hasUI: true, ui: { custom: async () => { throw new Error("UI failed"); } } },
+      );
+
+      expect(result.isError).toBe(true);
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
+   test("clears Herdr blocked lifecycle when freeform input is cancelled", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         { question: "Why?", options: [] },
+         undefined,
+         undefined,
+         { hasUI: true, ui: { input: async () => undefined } },
+      );
+
+      expect(result.details.cancelled).toBe(true);
+      expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
+         { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
+         { name: "herdr:blocked", payload: { active: false } },
+      ]);
+   });
+
    test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;

--- a/index.test.ts
+++ b/index.test.ts
@@ -1993,6 +1993,96 @@ describe("ask_user", () => {
       expect(longOutput).not.toContain("Long context detail.");
    });
 
+   test("bounds and scrolls expanded context in inline mode", async () => {
+      const tool = await setupTool();
+      let expanded: string[] = [];
+      let scrolled: string[] = [];
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: Array.from({ length: 20 }, (_, index) => `Inline context line ${index}`).join("\n"),
+            options: ["Alpha", "Beta"],
+            displayMode: "inline",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 12 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(50);
+                  component.handleInput("ctrl+e");
+                  expanded = component.render(50);
+                  component.handleInput("end");
+                  scrolled = component.render(50);
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(expanded.length).toBeLessThanOrEqual(10);
+      expect(expanded.join("\n")).toContain("Alpha");
+      expect(scrolled.join("\n")).toContain("Inline context line 19");
+      expect(scrolled.join("\n")).toContain("Alpha");
+      expect(scrolled.join("\n")).toContain("PgUp/P");
+   });
+
+   test("moves the context toggle when a configured shortcut owns ctrl+e", async () => {
+      const tool = await setupTool();
+      let help = "";
+      let commentEnabled = false;
+      let expanded = "";
+
+      await tool.execute(
+         "tool-call-id",
+         {
+            question: "Pick one",
+            context: "Long context detail. ".repeat(80),
+            options: ["Alpha", "Beta"],
+            allowComment: true,
+            commentToggleKey: "ctrl+e",
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 12 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  component.render(50);
+                  help = (component as any).helpText.render(120).join("\n");
+                  component.handleInput("ctrl+e");
+                  commentEnabled = (component as any).singleSelectList.isCommentEnabled();
+                  component.handleInput("ctrl+x");
+                  component.render(50);
+                  component.handleInput("end");
+                  expanded = component.render(50).join("\n");
+                  return null;
+               },
+            },
+         },
+      );
+
+      expect(help).toContain("ctrl+e toggle context");
+      expect(help).toContain("ctrl+x expand context");
+      expect(commentEnabled).toBe(true);
+      expect(expanded).toContain("Long context detail.");
+   });
+
    test("submits immediately when the comment toggle is off", async () => {
       const tool = await setupTool();
 

--- a/index.ts
+++ b/index.ts
@@ -380,8 +380,7 @@ const FREEFORM_SENTINEL = "\u270f\ufe0f Type custom response...";
 const COMMENT_TOGGLE_LABEL = "Add extra context after selection";
 const DEFAULT_OVERLAY_TOGGLE_KEY = "alt+o";
 const DEFAULT_COMMENT_TOGGLE_KEY = "ctrl+g";
-const CONTEXT_TOGGLE_KEY = Key.ctrl("e");
-const CONTEXT_TOGGLE_LABEL = "ctrl+e";
+const CONTEXT_TOGGLE_KEYS = [Key.ctrl("e"), Key.ctrl("x"), Key.ctrl("y")];
 const INLINE_CONTEXT_MAX_ROWS = 3;
 
 // Vim-style aliases for navigating option lists. ctrl+j/k are safe in the
@@ -1222,6 +1221,9 @@ class AskComponent extends Container {
    private renderInlineLayout(width: number, innerWidth: number): string[] {
       const fullContextLines = this.buildFullContextLines(innerWidth);
       this.setContextIsCollapsible(fullContextLines.length > INLINE_CONTEXT_MAX_ROWS);
+      if (this.contextExpanded) {
+         return this.renderOverlayLayout(width, innerWidth);
+      }
       const bodyLines = [
          ...this.buildPromptLines(innerWidth, fullContextLines),
          "",
@@ -1331,10 +1333,19 @@ class AskComponent extends Container {
       this.updateHelpText();
    }
 
+   private getContextToggleKey(): string {
+      const reserved = new Set(
+         [this.shortcuts.overlayToggle, this.shortcuts.commentToggle]
+            .filter((shortcut) => !shortcut.disabled)
+            .map((shortcut) => shortcut.spec),
+      );
+      return CONTEXT_TOGGLE_KEYS.find((key) => !reserved.has(key)) ?? CONTEXT_TOGGLE_KEYS[0]!;
+   }
+
    private buildContextDisplayLines(fullContextLines: string[], width: number): string[] {
       if (fullContextLines.length === 0) return [];
       if (!this.contextIsCollapsible || this.contextExpanded) return fullContextLines;
-      const label = `Context (${fullContextLines.length} lines) — ${CONTEXT_TOGGLE_LABEL} expand`;
+      const label = `Context (${fullContextLines.length} lines) — ${this.getContextToggleKey()} expand`;
       return [truncateToWidth(this.theme.fg("dim", label), width, "")];
    }
 
@@ -1587,7 +1598,7 @@ class AskComponent extends Container {
       const overlayHint = this.displayMode === "overlay" && !this.shortcuts.overlayToggle.disabled
          ? literalHint(theme, this.shortcuts.overlayToggle.spec, "hide")
          : null;
-      const promptScrollHint = this.displayMode === "overlay"
+      const promptScrollHint = this.displayMode === "overlay" || this.contextExpanded
          ? literalHint(theme, "PgUp/PgDn", "prompt")
          : null;
       const commentHint = this.allowComment && !this.shortcuts.commentToggle.disabled
@@ -1596,7 +1607,7 @@ class AskComponent extends Container {
       const contextHint = this.contextIsCollapsible
          ? literalHint(
             theme,
-            CONTEXT_TOGGLE_LABEL,
+            this.getContextToggleKey(),
             this.contextExpanded ? "collapse context" : "expand context",
          )
          : null;
@@ -1822,7 +1833,8 @@ class AskComponent extends Container {
    }
 
    private setPromptScrollOffset(nextOffset: number): boolean {
-      if (this.displayMode !== "overlay" || this.promptMaxScrollOffset <= 0) return false;
+      if (this.displayMode !== "overlay" && !this.contextExpanded) return false;
+      if (this.promptMaxScrollOffset <= 0) return false;
       const clamped = Math.max(0, Math.min(Math.floor(nextOffset), this.promptMaxScrollOffset));
       const changed = clamped !== this.promptScrollOffset;
       this.promptScrollOffset = clamped;
@@ -1830,7 +1842,8 @@ class AskComponent extends Container {
    }
 
    private handlePromptScrollInput(data: string): boolean {
-      if (this.displayMode !== "overlay" || this.promptMaxScrollOffset <= 0) return false;
+      if (this.displayMode !== "overlay" && !this.contextExpanded) return false;
+      if (this.promptMaxScrollOffset <= 0) return false;
       // Prompt scrolling is select-mode only: in freeform/comment modes the
       // editor owns PageUp/PageDown (tui.editor.pageUp/pageDown) for paging
       // through long input, so intercepting them here would steal editor keys.
@@ -1864,7 +1877,7 @@ class AskComponent extends Container {
    }
 
    handleInput(data: string): void {
-      if (matchesKey(data, CONTEXT_TOGGLE_KEY) && this.toggleContext()) {
+      if (matchesKey(data, this.getContextToggleKey() as any) && this.toggleContext()) {
          return;
       }
       if (this.handlePromptScrollInput(data)) {

--- a/index.ts
+++ b/index.ts
@@ -87,6 +87,7 @@ function safeMarkdownTheme(): MarkdownTheme | undefined {
 type AskOptionInput = QuestionOption | string;
 
 type AskDisplayMode = "overlay" | "inline";
+type AskSingleSelectLayout = "auto" | "list";
 
 interface AskParams {
    question: string;
@@ -96,6 +97,7 @@ interface AskParams {
    allowFreeform?: boolean;
    allowComment?: boolean;
    displayMode?: AskDisplayMode;
+   singleSelectLayout?: AskSingleSelectLayout;
    overlayToggleKey?: string | null;
    commentToggleKey?: string | null;
    timeout?: number;
@@ -733,6 +735,7 @@ class WrappedSingleSelectList implements Component {
    private allowFreeform: boolean;
    private allowComment: boolean;
    private theme: Theme;
+   private singleSelectLayout: AskSingleSelectLayout;
    private keybindings: KeybindingsManager;
    private commentToggle: ResolvedShortcut;
    private selectedIndex = 0;
@@ -751,6 +754,7 @@ class WrappedSingleSelectList implements Component {
       allowFreeform: boolean,
       allowComment: boolean,
       theme: Theme,
+      singleSelectLayout: AskSingleSelectLayout,
       keybindings: KeybindingsManager,
       commentToggle: ResolvedShortcut,
    ) {
@@ -758,6 +762,7 @@ class WrappedSingleSelectList implements Component {
       this.allowFreeform = allowFreeform;
       this.allowComment = allowComment;
       this.theme = theme;
+      this.singleSelectLayout = singleSelectLayout;
       this.keybindings = keybindings;
       this.commentToggle = commentToggle;
    }
@@ -855,6 +860,7 @@ class WrappedSingleSelectList implements Component {
    }
 
    private getSplitPaneWidths(width: number): { left: number; right: number } | null {
+      if (this.singleSelectLayout === "list") return null;
       if (width < SINGLE_SELECT_SPLIT_PANE_MIN_WIDTH) return null;
 
       const availableWidth = width - SINGLE_SELECT_SPLIT_PANE_SEPARATOR.length;
@@ -1083,6 +1089,7 @@ class AskComponent extends Container {
    private allowFreeform: boolean;
    private allowComment: boolean;
    private displayMode: AskDisplayMode;
+   private singleSelectLayout: AskSingleSelectLayout;
    private tui: TUI;
    private theme: Theme;
    private keybindings: KeybindingsManager;
@@ -1131,6 +1138,7 @@ class AskComponent extends Container {
       allowFreeform: boolean,
       allowComment: boolean,
       displayMode: AskDisplayMode,
+      singleSelectLayout: AskSingleSelectLayout,
       tui: TUI,
       theme: Theme,
       keybindings: KeybindingsManager,
@@ -1146,6 +1154,7 @@ class AskComponent extends Container {
       this.allowFreeform = allowFreeform;
       this.allowComment = allowComment;
       this.displayMode = displayMode;
+      this.singleSelectLayout = singleSelectLayout;
       this.tui = tui;
       this.theme = theme;
       this.keybindings = keybindings;
@@ -1676,6 +1685,7 @@ class AskComponent extends Container {
          this.allowFreeform,
          this.allowComment,
          this.theme,
+         this.singleSelectLayout,
          this.keybindings,
          this.shortcuts.commentToggle,
       );
@@ -2033,6 +2043,11 @@ export default function(pi: ExtensionAPI) {
                description: "UI rendering mode. 'overlay' shows a centered modal, 'inline' renders in-place. Default: PI_ASK_USER_DISPLAY_MODE env var if set, otherwise 'overlay'. Omit to respect the user's configured preference.",
             }),
          ),
+         singleSelectLayout: Type.Optional(
+            StringEnum(["auto", "list"] as const, {
+               description: "Single-select layout. 'auto' uses a details pane on wide terminals; 'list' always keeps descriptions below options. Default: PI_ASK_USER_SINGLE_SELECT_LAYOUT if set, otherwise 'auto'.",
+            }),
+         ),
          overlayToggleKey: Type.Optional(
             Type.String({
                description:
@@ -2066,6 +2081,7 @@ export default function(pi: ExtensionAPI) {
             allowFreeform = true,
             allowComment: requestedAllowComment,
             displayMode,
+            singleSelectLayout,
             overlayToggleKey,
             commentToggleKey,
             timeout,
@@ -2074,6 +2090,9 @@ export default function(pi: ExtensionAPI) {
          const envDisplayMode: AskDisplayMode | undefined =
             envMode === "overlay" || envMode === "inline" ? envMode : undefined;
          const effectiveDisplayMode: AskDisplayMode = displayMode ?? envDisplayMode ?? "overlay";
+         const envSingleSelectLayout = process.env.PI_ASK_USER_SINGLE_SELECT_LAYOUT?.trim().toLowerCase();
+         const effectiveSingleSelectLayout: AskSingleSelectLayout = singleSelectLayout
+            ?? (envSingleSelectLayout === "list" ? "list" : "auto");
          const allowComment = requestedAllowComment
             ?? parseBooleanPreference(process.env.PI_ASK_USER_ALLOW_COMMENT)
             ?? false;
@@ -2179,6 +2198,7 @@ export default function(pi: ExtensionAPI) {
                   allowFreeform,
                   allowComment,
                   effectiveDisplayMode,
+                  effectiveSingleSelectLayout,
                   tui,
                   theme,
                   keybindings,

--- a/index.ts
+++ b/index.ts
@@ -1248,14 +1248,16 @@ class AskComponent extends Container {
       let helpFullLines = this.helpText.render(innerWidth);
       const questionLines = this.buildQuestionLines(innerWidth);
       const fullContextLines = this.buildFullContextLines(innerWidth);
-      const shouldCollapse = this.mode === "select"
-         ? this.shouldCollapseContextForOverlay(
-            questionLines.length,
-            fullContextLines.length,
-            bodyCapacity,
-            helpFullLines.length,
-         )
-         : this.contextIsCollapsible;
+      const shouldCollapse = this.displayMode === "inline"
+         ? this.contextIsCollapsible
+         : this.mode === "select"
+            ? this.shouldCollapseContextForOverlay(
+               questionLines.length,
+               fullContextLines.length,
+               bodyCapacity,
+               helpFullLines.length,
+            )
+            : this.contextIsCollapsible;
       this.setContextIsCollapsible(shouldCollapse);
       helpFullLines = this.helpText.render(innerWidth);
       const promptLines = this.buildPromptLines(innerWidth, fullContextLines);

--- a/index.ts
+++ b/index.ts
@@ -380,6 +380,9 @@ const FREEFORM_SENTINEL = "\u270f\ufe0f Type custom response...";
 const COMMENT_TOGGLE_LABEL = "Add extra context after selection";
 const DEFAULT_OVERLAY_TOGGLE_KEY = "alt+o";
 const DEFAULT_COMMENT_TOGGLE_KEY = "ctrl+g";
+const CONTEXT_TOGGLE_KEY = Key.ctrl("e");
+const CONTEXT_TOGGLE_LABEL = "ctrl+e";
+const INLINE_CONTEXT_MAX_ROWS = 3;
 
 // Vim-style aliases for navigating option lists. ctrl+j/k are safe in the
 // searchable single-select because they don't collide with fuzzy-search input.
@@ -1094,6 +1097,8 @@ class AskComponent extends Container {
    private promptScrollOffset = 0;
    private promptMaxScrollOffset = 0;
    private promptViewportRows = 0;
+   private contextIsCollapsible = false;
+   private contextExpanded = false;
 
    // Static layout components
    private titleText: Text;
@@ -1211,7 +1216,20 @@ class AskComponent extends Container {
          this.ensureSingleSelectList().setMaxVisibleRows(12);
       }
 
-      return this.frameRawLines(super.render(innerWidth), width, innerWidth);
+      return this.renderInlineLayout(width, innerWidth);
+   }
+
+   private renderInlineLayout(width: number, innerWidth: number): string[] {
+      const fullContextLines = this.buildFullContextLines(innerWidth);
+      this.setContextIsCollapsible(fullContextLines.length > INLINE_CONTEXT_MAX_ROWS);
+      const bodyLines = [
+         ...this.buildPromptLines(innerWidth, fullContextLines),
+         "",
+         ...this.modeContainer.render(innerWidth),
+         "",
+         ...this.helpText.render(innerWidth),
+      ];
+      return this.frameBodyLines(bodyLines, width, innerWidth);
    }
 
    private getOverlayMaxRenderLines(): number {
@@ -1225,8 +1243,20 @@ class AskComponent extends Container {
       if (maxLines === 2) return [this.renderTopBorder(width), this.renderBottomBorder(width)];
 
       const bodyCapacity = Math.max(0, maxLines - 2);
-      const promptLines = this.buildPromptLines(innerWidth);
-      const helpFullLines = this.helpText.render(innerWidth);
+      let helpFullLines = this.helpText.render(innerWidth);
+      const questionLines = this.buildQuestionLines(innerWidth);
+      const fullContextLines = this.buildFullContextLines(innerWidth);
+      const shouldCollapse = this.mode === "select"
+         ? this.shouldCollapseContextForOverlay(
+            questionLines.length,
+            fullContextLines.length,
+            bodyCapacity,
+            helpFullLines.length,
+         )
+         : this.contextIsCollapsible;
+      this.setContextIsCollapsible(shouldCollapse);
+      helpFullLines = this.helpText.render(innerWidth);
+      const promptLines = this.buildPromptLines(innerWidth, fullContextLines);
       const helpBudget = this.getOverlayHelpBudget(bodyCapacity, helpFullLines.length);
       const contentRows = Math.max(0, bodyCapacity - helpBudget);
 
@@ -1247,9 +1277,10 @@ class AskComponent extends Container {
             modeBudget = Math.max(modeMinRows, modeBudget);
             promptBudget = promptAndModeRows - modeBudget;
 
+            const usefulPromptTarget = this.contextIsCollapsible && !this.contextExpanded ? 3 : 2;
             const usefulPromptRows = Math.min(
                promptLines.length,
-               promptAndModeRows >= modeMinRows + 2 ? 2 : promptMinRows,
+               promptAndModeRows >= modeMinRows + usefulPromptTarget ? usefulPromptTarget : promptMinRows,
             );
             if (promptBudget < usefulPromptRows && modeBudget > modeMinRows) {
                const shiftedRows = Math.min(usefulPromptRows - promptBudget, modeBudget - modeMinRows);
@@ -1284,12 +1315,54 @@ class AskComponent extends Container {
       return this.frameBodyLines(bodyLines.slice(0, bodyCapacity), width, innerWidth);
    }
 
-   private buildPromptLines(width: number): string[] {
+   private buildQuestionLines(width: number): string[] {
+      return this.questionText.render(width);
+   }
+
+   private buildFullContextLines(width: number): string[] {
+      if (!this.contextComponent) return [];
+      return this.contextComponent.render(width);
+   }
+
+   private setContextIsCollapsible(value: boolean): void {
+      if (this.contextIsCollapsible === value) return;
+      this.contextIsCollapsible = value;
+      if (!value) this.contextExpanded = false;
+      this.updateHelpText();
+   }
+
+   private buildContextDisplayLines(fullContextLines: string[], width: number): string[] {
+      if (fullContextLines.length === 0) return [];
+      if (!this.contextIsCollapsible || this.contextExpanded) return fullContextLines;
+      const label = `Context (${fullContextLines.length} lines) — ${CONTEXT_TOGGLE_LABEL} expand`;
+      return [truncateToWidth(this.theme.fg("dim", label), width, "")];
+   }
+
+   private buildPromptLines(width: number, fullContextLines: string[]): string[] {
+      const questionLines = this.buildQuestionLines(width);
+      const contextLines = this.buildContextDisplayLines(fullContextLines, width);
+      const contextSeparator = this.contextIsCollapsible && !this.contextExpanded ? [] : [""];
       return [
-         ...this.titleText.render(width),
-         ...this.questionText.render(width),
-         ...(this.contextComponent ? ["", ...this.contextComponent.render(width)] : []),
+         ...questionLines,
+         ...(contextLines.length > 0 ? [...contextSeparator, ...contextLines] : []),
       ];
+   }
+
+   private shouldCollapseContextForOverlay(
+      questionRows: number,
+      contextRows: number,
+      bodyCapacity: number,
+      helpRows: number,
+   ): boolean {
+      if (contextRows === 0) return false;
+      const helpBudget = this.getOverlayHelpBudget(bodyCapacity, helpRows);
+      const contentRows = Math.max(0, bodyCapacity - helpBudget);
+      const separatorRows = contentRows >= 4 ? 1 : 0;
+      const promptCapacity = Math.max(
+         0,
+         contentRows - separatorRows - this.getMinimumModeRows(),
+      );
+      return questionRows + 1 + contextRows > promptCapacity;
    }
 
    private getOverlayHelpBudget(bodyCapacity: number, renderedHelpRows: number): number {
@@ -1301,7 +1374,7 @@ class AskComponent extends Container {
    private getMinimumModeRows(): number {
       if (this.mode === "freeform") return 5;
       if (this.mode === "comment") return 6;
-      return this.allowMultiple ? 3 : 4;
+      return 3;
    }
 
    private getPreferredModeRows(): number {
@@ -1520,6 +1593,13 @@ class AskComponent extends Container {
       const commentHint = this.allowComment && !this.shortcuts.commentToggle.disabled
          ? literalHint(theme, this.shortcuts.commentToggle.spec, "toggle context")
          : null;
+      const contextHint = this.contextIsCollapsible
+         ? literalHint(
+            theme,
+            CONTEXT_TOGGLE_LABEL,
+            this.contextExpanded ? "collapse context" : "expand context",
+         )
+         : null;
       if (this.mode === "freeform" || this.mode === "comment") {
          const alternateCancelKeys = this.keybindings
             .getKeys("tui.select.cancel")
@@ -1542,6 +1622,7 @@ class AskComponent extends Container {
             literalHint(theme, "↑↓", "navigate"),
             literalHint(theme, "space", "toggle"),
             commentHint,
+            contextHint,
             promptScrollHint,
             overlayHint,
             keybindingHint(theme, this.keybindings, "tui.select.confirm", "submit"),
@@ -1557,6 +1638,7 @@ class AskComponent extends Container {
          const hints = [
             literalHint(theme, "type", "filter"),
             commentHint,
+            contextHint,
             promptScrollHint,
             keybindingHint(theme, this.keybindings, "tui.editor.deleteCharBackward", "erase"),
             literalHint(theme, "↑↓", "navigate"),
@@ -1730,6 +1812,15 @@ class AskComponent extends Container {
       this.tui.requestRender();
    }
 
+   private toggleContext(): boolean {
+      if (this.mode !== "select" || !this.contextIsCollapsible) return false;
+      this.contextExpanded = !this.contextExpanded;
+      this.promptScrollOffset = 0;
+      this.invalidate();
+      this.tui.requestRender();
+      return true;
+   }
+
    private setPromptScrollOffset(nextOffset: number): boolean {
       if (this.displayMode !== "overlay" || this.promptMaxScrollOffset <= 0) return false;
       const clamped = Math.max(0, Math.min(Math.floor(nextOffset), this.promptMaxScrollOffset));
@@ -1773,6 +1864,9 @@ class AskComponent extends Container {
    }
 
    handleInput(data: string): void {
+      if (matchesKey(data, CONTEXT_TOGGLE_KEY) && this.toggleContext()) {
+         return;
+      }
       if (this.handlePromptScrollInput(data)) {
          this.tui.requestRender();
          return;

--- a/index.ts
+++ b/index.ts
@@ -2018,7 +2018,13 @@ export default function(pi: ExtensionAPI) {
 
          if (options.length === 0) {
             const prompt = normalizedContext ? `${question}\n\nContext:\n${normalizedContext}` : question;
-            const answer = await ctx.ui.input(prompt, "Type your answer...", timeout ? { timeout } : undefined);
+            pi.events.emit("herdr:blocked", { active: true, label: "Waiting for user response" });
+            let answer: string | undefined;
+            try {
+               answer = await ctx.ui.input(prompt, "Type your answer...", timeout ? { timeout } : undefined);
+            } finally {
+               pi.events.emit("herdr:blocked", { active: false });
+            }
             const response = createFreeformResponse(answer);
 
             if (!response) {
@@ -2044,6 +2050,7 @@ export default function(pi: ExtensionAPI) {
          let overlayHandle: OverlayHandle | undefined;
          let removeOverlayInputListener: (() => void) | undefined;
          let hasAnnouncedHide = false;
+         pi.events.emit("herdr:blocked", { active: true, label: "Waiting for user response" });
          try {
             const customFactory = (tui: TUI, theme: Theme, keybindings: KeybindingsManager, done: (result: AskUIResult | null) => void) => {
                if (signal) {
@@ -2116,6 +2123,7 @@ export default function(pi: ExtensionAPI) {
             };
          } finally {
             removeOverlayInputListener?.();
+            pi.events.emit("herdr:blocked", { active: false });
          }
 
          if (result === null) {


### PR DESCRIPTION
## Summary
- collapse and expand oversized context on small overlay and inline prompts
- emit `herdr:blocked` while structured or freeform input is awaiting the user
- add `singleSelectLayout: auto | list` and `PI_ASK_USER_SINGLE_SELECT_LAYOUT`
- document the new controls and preferences

## Verification
- `bun test` — 82 passed
- `npm run check`

Closes #30. Supersedes #27 and #32.