### PR TITLE
fix: ignore overlay toggle release events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Configurable `auto` or always-single-column layouts for wide single-select prompts. Closes #30.
 - `herdr:blocked` lifecycle events while waiting for structured or freeform user input.
 
+### Fixed
+
+- The overlay visibility shortcut now ignores Kitty keyboard repeat and release events, preventing one `alt+o` keypress from hiding and immediately reopening the prompt.
+
 ## [0.13.1](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.1) - 2026-08-01
 
 ### Fixed
@@ -106,7 +110,6 @@
 - `ask_user` result details and emitted `ask:answered` events now use a structured `response` union instead of flattening everything into `answer` / `wasCustom`
 - Expanded result rendering now shows selection comments separately from chosen options
 
-
 ## [0.5.2](https://github.com/edlsh/pi-ask-user/releases/tag/v0.5.2) - 2026-04-06
 
 ### Fixed
@@ -136,7 +139,6 @@
 - Overlay freeform answers now preserve `wasCustom: true` in both emitted events and returned `details` metadata
 - Out-of-range number keys in searchable single-select now fall through to filtering instead of being silently swallowed
 - Exact-width word wrapping no longer duplicates preceding short text in wrapped descriptions
-
 
 ## [0.4.1](https://github.com/edlsh/pi-ask-user/releases/tag/v0.4.1) - 2026-03-22
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -168,7 +168,10 @@ beforeAll(() => {
             return super.render().map((line) => this.mdTheme.bold(line));
          }
       },
-      matchesKey: (data: string, key: string) => data === key,
+      matchesKey: (data: string, key: string) => data === key
+         || (key === "alt+o" && /^\x1b\[111;3:[123]u$/.test(data)),
+      isKeyRepeat: (data: string) => data.includes(":2u"),
+      isKeyRelease: (data: string) => data.includes(":3u"),
       Spacer: class {
          render() {
             return [""];
@@ -669,10 +672,16 @@ describe("ask_user", () => {
                ui: {
                   custom: async (_factory: any, options: any) => {
                      options.onHandle?.(handle);
-                     // Simulate the user pressing alt+o twice while the overlay is shown.
-                     const firstResult = inputHandler?.("alt+o");
-                     const secondResult = inputHandler?.("alt+o");
+                     // Kitty progressive keyboard reporting emits repeat and
+                     // release events in addition to the initial press. They
+                     // must be consumed without toggling the overlay again.
+                     const firstResult = inputHandler?.("\x1b[111;3:1u");
+                     const repeatResult = inputHandler?.("\x1b[111;3:2u");
+                     const releaseResult = inputHandler?.("\x1b[111;3:3u");
+                     const secondResult = inputHandler?.("\x1b[111;3:1u");
                      expect(firstResult).toEqual({ consume: true });
+                     expect(repeatResult).toEqual({ consume: true });
+                     expect(releaseResult).toEqual({ consume: true });
                      expect(secondResult).toEqual({ consume: true });
                      return null;
                   },

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,8 @@ import {
    Editor,
    type EditorTheme,
    fuzzyFilter,
+   isKeyRelease,
+   isKeyRepeat,
    Key,
    type Keybinding,
    type KeybindingsManager,
@@ -2219,6 +2221,12 @@ export default function(pi: ExtensionAPI) {
             ) {
                removeOverlayInputListener = ctx.ui.onTerminalInput((data) => {
                   if (!overlayToggle.matches(data) || !overlayHandle) return undefined;
+                  // Kitty's progressive keyboard protocol reports press, repeat,
+                  // and release as separate events. Toggle only on the initial
+                  // press; otherwise one physical keypress can immediately hide
+                  // and re-show the overlay. Still consume repeat/release events
+                  // so they do not reach the component focused behind it.
+                  if (isKeyRepeat(data) || isKeyRelease(data)) return { consume: true };
                   const nextHidden = !overlayHandle.isHidden();
                   overlayHandle.setHidden(nextHidden);
                   if (nextHidden && !hasAnnouncedHide) {


### PR DESCRIPTION
## Summary

- ignore Kitty keyboard repeat and release events in the global overlay-toggle listener
- consume those events so they cannot reach the component focused behind a hidden overlay
- cover press, repeat, and release CSI sequences with a regression test
- document the fix in the changelog

## Why

With Kitty progressive keyboard reporting, one physical `alt+o` press emits separate press and release events. Both matched the configured shortcut, so the overlay hid and immediately reopened. Repeat events could also toggle it repeatedly.

## Verification

- `bun test` — 82 passed, 0 failed
- `npm run check`
- manually verified that `alt+o` toggles once per physical keypress