### PR TITLE
feat: add number shortcut for custom responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- The custom/freeform response row now displays the next option number and opens directly when that number key is pressed, without changing canned-answer number-key behavior.
 - Responsive context collapse for overlay and inline prompts; oversized context preserves the full value while keeping the question and choices visible, and `ctrl+e` toggles the expanded view.
 - Configurable `auto` or always-single-column layouts for wide single-select prompts. Closes #30.
 - `herdr:blocked` lifecycle events while waiting for structured or freeform user input.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ While an `ask_user` prompt is open:
 | `alt+o` (configurable via `overlayToggleKey`) | Hide/show the overlay popup so you can read the agent's prior output. Available in `overlay` mode only. The first time you hide it, a notification reminds you which key brings it back. |
 | `ctrl+g` (configurable via `commentToggleKey`) | Toggle the optional comment/extra-context row (when `allowComment: true`). |
 | `ctrl+e` | Expand or collapse oversized context while choosing an option. If another configured ask shortcut owns it, the prompt shows `ctrl+x` or `ctrl+y` instead. |
+| `1`–`9` | Select the correspondingly numbered row. Canned answers retain their existing single- or multi-select behavior; the numbered custom-response row opens the freeform editor. |
 | `enter` | Confirm the focused option, submit a freeform response, or submit/skip an optional comment. |
 | `esc` | Clear the search filter, exit freeform/comment mode, or cancel the prompt. |
 | `↑` / `↓`, `ctrl+k` / `ctrl+j` | Navigate options. `ctrl+k` / `ctrl+j` (vim-style) work while typing in searchable prompts without disturbing the filter. |

--- a/index.test.ts
+++ b/index.test.ts
@@ -1031,6 +1031,128 @@ describe("ask_user", () => {
       expect(result.details.cancelled).toBe(true);
    });
 
+   test("keeps canned single-select number keys as highlight-only shortcuts", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["Alpha", "Beta"],
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  let resolved: string | null | undefined;
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     (value: string | null) => {
+                        resolved = value;
+                     },
+                  );
+
+                  component.handleInput("2");
+                  expect(resolved).toBeUndefined();
+                  component.handleInput("enter");
+                  return resolved ?? null;
+               },
+            },
+         },
+      );
+
+      expect(result.details.response).toEqual({ kind: "selection", selections: ["Beta"] });
+      expect(result.details.cancelled).toBe(false);
+   });
+
+   test("enters freeform mode by pressing its number in single-select mode", async () => {
+      const tool = await setupTool();
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: ["Alpha", "Beta"],
+            allowFreeform: true,
+            allowComment: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  let resolved: string | null | undefined;
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     (value: string | null) => {
+                        resolved = value;
+                     },
+                  );
+
+                  component.handleInput("3");
+                  editorText = "A custom answer";
+                  component.handleInput("enter");
+                  return resolved ?? null;
+               },
+            },
+         },
+      );
+
+      expect(result.details.response).toEqual({ kind: "freeform", text: "A custom answer" });
+      expect(result.details.cancelled).toBe(false);
+   });
+
+   test("enters freeform mode by pressing its number in multi-select mode", async () => {
+      const tool = await setupTool();
+      let rendered = "";
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which options should we use?",
+            options: ["Alpha", "Beta"],
+            allowMultiple: true,
+            allowFreeform: true,
+            allowComment: true,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  let resolved: unknown;
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 24 } },
+                     createTheme(),
+                     createKeybindings(),
+                     (value: unknown) => {
+                        resolved = value;
+                     },
+                  );
+
+                  rendered = ((component as any).multiSelectList as any).render(80).join("\n");
+                  component.handleInput("3");
+                  editorText = "Another custom answer";
+                  component.handleInput("enter");
+                  return resolved ?? null;
+               },
+            },
+         },
+      );
+
+      expect(rendered).toContain("3. Type something.");
+      expect(result.details.response).toEqual({ kind: "freeform", text: "Another custom answer" });
+      expect(result.details.cancelled).toBe(false);
+   });
+
    test("uses shared confirm keybinding in single-select mode", async () => {
       const tool = await setupTool();
 

--- a/index.ts
+++ b/index.ts
@@ -577,6 +577,10 @@ class MultiSelectList implements Component {
             this.toggle(idx);
             this.selectedIndex = Math.min(idx, count - 1);
             this.invalidate();
+         } else if (this.allowFreeform && idx === this.options.length) {
+            this.selectedIndex = this.getFreeformIndex();
+            this.invalidate();
+            this.onEnterFreeform?.();
          }
          return;
       }
@@ -650,9 +654,10 @@ class MultiSelectList implements Component {
          }
 
          if (this.isFreeformRow(i)) {
+            const num = theme.fg("dim", `${this.options.length + 1}.`);
             const label = theme.fg("text", theme.bold("Type something."));
             const desc = theme.fg("muted", "Enter a custom response");
-            const line = `${prefix}   ${label} ${theme.fg("dim", "—")} ${desc}`;
+            const line = `${prefix} ${num} ${label} ${theme.fg("dim", "—")} ${desc}`;
             block.push(truncateToWidth(line, width, ""));
             blocks.push(block);
             continue;
@@ -1004,11 +1009,17 @@ class WrappedSingleSelectList implements Component {
       }
 
       const numMatch = data.match(/^[1-9]$/);
-      if (numMatch && filteredOptions.length > 0) {
+      if (numMatch) {
          const idx = Number.parseInt(numMatch[0], 10) - 1;
          if (idx >= 0 && idx < filteredOptions.length) {
             this.selectedIndex = idx;
             this.invalidate();
+            return;
+         }
+         if (this.allowFreeform && idx === filteredOptions.length) {
+            this.selectedIndex = filteredOptions.length + (this.allowComment ? 1 : 0);
+            this.invalidate();
+            this.onEnterFreeform?.();
             return;
          }
       }

--- a/single-select-layout.test.ts
+++ b/single-select-layout.test.ts
@@ -83,6 +83,20 @@ describe("renderSingleSelectRows", () => {
 		expect(rows.map((r) => r.line).filter((line) => line.trim() === "aaaaaaaa")).toHaveLength(2);
 	});
 
+	test("numbers the freeform response after the canned options", () => {
+		const rows = renderSingleSelectRows({
+			options: [{ title: "Alpha" }, { title: "Beta" }],
+			selectedIndex: 3,
+			width: 60,
+			allowFreeform: true,
+			allowComment: true,
+		});
+
+		const rendered = rows.map((row) => row.line).join("\n");
+		expect(rendered).toContain("3. Type something.");
+		expect(rendered).not.toContain("4. Type something.");
+	});
+
 	test("marks selected item rows as selected in annotated output", () => {
 		const rows = renderSingleSelectRows({
 			options: [

--- a/single-select-layout.ts
+++ b/single-select-layout.ts
@@ -101,7 +101,7 @@ function buildItemBlocks(
 		const pointer = itemIndex === selectedIndex ? "→" : " ";
 		const lines: string[] = [];
 
-		if (item.type === "comment-toggle" || item.type === "freeform") {
+		if (item.type === "comment-toggle") {
 			const prefix = `${pointer}   `;
 			const wrapped = wrapText(item.option.title, Math.max(8, normalizedWidth - prefix.length));
 			wrapped.forEach((line, lineIndex) => {
@@ -110,7 +110,8 @@ function buildItemBlocks(
 			return { itemIndex, lines };
 		}
 
-		const numberPrefix = `${pointer} ${itemIndex + 1}. `;
+		const optionNumber = item.type === "freeform" ? options.length + 1 : itemIndex + 1;
+		const numberPrefix = `${pointer} ${optionNumber}. `;
 		const continuationPrefix = " ".repeat(numberPrefix.length);
 		const titleLines = wrapText(item.option.title, Math.max(8, normalizedWidth - numberPrefix.length));
 		titleLines.forEach((line, lineIndex) => {


### PR DESCRIPTION
## Summary

Make the custom/freeform response behave like a numbered option. Users can now press its displayed number to open the freeform editor directly in both single- and multi-select prompts, while canned-answer number keys retain their existing behavior.

## Changes

- Display the custom-response row with the next available option number.
- Open the freeform editor when that number is pressed in single- or multi-select mode.
- Preserve highlight-only number shortcuts for canned single-select answers.
- Document the shortcut and add regression coverage for rendering and input behavior.

## Testing

- `bun test` — 86 passed, 0 failed
- `npm run check`
- LSP diagnostics — clean

## Notes

The shortcut is limited to `1`–`9`, matching the existing numbered-option behavior.
