### PR TITLE
fix: expand overlay option lists into unused space

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1720,6 +1720,44 @@ describe("ask_user", () => {
       expect(rendered).toContain("The alpha option keeps the rollout conservative.");
    });
 
+   test("expands the option viewport into unused prompt space on tall terminals", async () => {
+      const tool = await setupTool();
+      let rendered: string[] = [];
+
+      const result = await tool.execute(
+         "tool-call-id",
+         {
+            question: "Which option should we use?",
+            options: Array.from({ length: 15 }, (_, index) => `Option ${index + 1}`),
+            allowFreeform: false,
+         },
+         undefined,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               custom: async (factory: any) => {
+                  const component = factory(
+                     { requestRender() { }, terminal: { rows: 40 } },
+                     createTheme(),
+                     createKeybindings(),
+                     () => { },
+                  );
+                  rendered = component.render(80);
+                  return null;
+               },
+            },
+         },
+      );
+
+      const joined = rendered.join("\n");
+      expect(result.isError).not.toBe(true);
+      expect(rendered.length).toBeLessThanOrEqual(34);
+      expect(rendered.length).toBeGreaterThan(16);
+      expect(joined).toContain("Option 15");
+      expect(joined).not.toContain("(1/15)");
+   });
+
    test.each([
       { width: 40, rows: 12 },
       { width: 60, rows: 20 },

--- a/index.ts
+++ b/index.ts
@@ -1300,6 +1300,12 @@ class AskComponent extends Container {
                modeBudget -= shiftedRows;
                promptBudget += shiftedRows;
             }
+
+            // Let overflowing choices use prompt capacity that would otherwise
+            // remain blank when the question and context are short.
+            const unusedPromptRows = Math.max(0, promptBudget - promptLines.length);
+            promptBudget -= unusedPromptRows;
+            modeBudget += unusedPromptRows;
          }
       } else {
          modeBudget = Math.min(this.getPreferredModeRows(), contentRows);


### PR DESCRIPTION
## Summary

Allow long option lists to use overlay rows left unused by short questions and context. On tall terminals this displays more choices at once instead of imposing a small option viewport and unnecessary scrolling.

## Changes

- Reassign unused prompt-row budget to the answer-mode viewport.
- Preserve the existing total overlay height limit and constrained-layout behavior.
- Add a regression test showing all 15 choices on a 40-row terminal without a scroll-position indicator.

## Testing

- `bun test` — 83 passed, 0 failed
- `npm run check`
- LSP diagnostics — clean

## Notes

The branch contains one focused commit and merges cleanly with current `main`.