### PR TITLE
fix: ignore kitty-protocol key release/repeat events in alt+o overlay toggle

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -168,7 +168,17 @@ beforeAll(() => {
             return super.render().map((line) => this.mdTheme.bold(line));
          }
       },
-      matchesKey: (data: string, key: string) => data === key,
+      isKeyRelease: (data: string) => data === "\x1b[111;3:3u",
+      isKeyRepeat: (data: string) => data === "\x1b[111;3:2u",
+      matchesKey: (data: string, key: string) => {
+         if (data === key) return true;
+         // Mirror pi-tui's real behavior for alt+letter under the kitty keyboard
+         // protocol: press, repeat, and release CSI-u sequences all match
+         // (e.g. ESC[111;3u / ESC[111;3:2u / ESC[111;3:3u for alt+o).
+         const match = /^\x1b\[(\d+);3(?::\d+)?u$/.exec(data);
+         if (!match) return false;
+         return Number(match[1]) === key.split("+").pop()!.charCodeAt(0);
+      },
       Spacer: class {
          render() {
             return [""];
@@ -691,6 +701,48 @@ describe("ask_user", () => {
          expect(notifications).toHaveLength(1);
          expect(notifications[0]?.message).toContain("alt+o");
          expect(notifications[0]?.type).toBe("info");
+      });
+
+      test("ignores kitty-protocol key-release and key-repeat sequences for alt+o", async () => {
+         const tool = await setupTool();
+         const { handle, calls } = createOverlayHandle();
+         let inputHandler: ((data: string) => any) | undefined;
+         const results: Array<{ seq: string; result: any }> = [];
+
+         await tool.execute(
+            "tool-call-id",
+            { question: "Q", options: ["A"] },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (_factory: any, options: any) => {
+                     options.onHandle?.(handle);
+                     // Press (CSI-u, no event type), release (event type 3), and
+                     // repeat (event type 2) sequences for alt+o. Assertions run
+                     // after execute() because the extension catches custom()
+                     // rejections and would swallow expect() failures here.
+                     results.push({ seq: "press", result: inputHandler?.("\x1b[111;3u") });
+                     results.push({ seq: "release", result: inputHandler?.("\x1b[111;3:3u") });
+                     results.push({ seq: "repeat", result: inputHandler?.("\x1b[111;3:2u") });
+                     return null;
+                  },
+                  onTerminalInput: (handler: (data: string) => any) => {
+                     inputHandler = handler;
+                     return () => { };
+                  },
+                  notify: () => { },
+               },
+            },
+         );
+
+         // The press hides the overlay; the release and repeat sequences must
+         // not re-show it (they previously matched alt+o like a press).
+         expect(results[0]?.result).toEqual({ consume: true });
+         expect(results[1]?.result).toBeUndefined();
+         expect(results[2]?.result).toBeUndefined();
+         expect(calls).toEqual([true]);
       });
 
       test("does not consume ctrl+o from the terminal listener", async () => {

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,8 @@ import {
    Editor,
    type EditorTheme,
    fuzzyFilter,
+   isKeyRelease,
+   isKeyRepeat,
    Key,
    type Keybinding,
    type KeybindingsManager,
@@ -2218,6 +2220,12 @@ export default function(pi: ExtensionAPI) {
                && typeof ctx.ui.onTerminalInput === "function"
             ) {
                removeOverlayInputListener = ctx.ui.onTerminalInput((data) => {
+                  // The kitty keyboard protocol (enabled by pi) sends separate press,
+                  // repeat, and release CSI-u sequences. matchesKey() matches all
+                  // event types, so without this filter one physical press toggles
+                  // twice: keydown hides the overlay, keyup re-shows it. One press
+                  // must be exactly one toggle.
+                  if (isKeyRelease(data) || isKeyRepeat(data)) return undefined;
                   if (!overlayToggle.matches(data) || !overlayHandle) return undefined;
                   const nextHidden = !overlayHandle.isHidden();
                   overlayHandle.setHidden(nextHidden);


### PR DESCRIPTION
Fixes #46

With pi's kitty keyboard protocol enabled (flags=7, event reporting),
terminals like Ghostty send separate press, repeat, and release CSI-u
sequences for the same key (ESC[111;3u / ESC[111;3:2u / ESC[111;3:3u
for alt+o). matchesKey() matches all event types, so the raw terminal
input listener toggled on keyup as well as keydown: one press flashed
the overlay away and back, and coalesced press+release chunks were
dropped without matching.

The listener now ignores isKeyRelease and isKeyRepeat events, so one
physical press is exactly one toggle. index.test.ts extends the mocked
matchesKey to mirror pi-tui's real kitty-protocol matching, and the
regression test drives the three sequences through the listener and
checks the overlay stays hidden after release and repeat.

Validation:
- bun test: 83 pass, 0 fail. The new test fails without the fix and
  passes with it.
- tsc --noEmit --skipLibCheck index.ts: clean.
- Tested on Ghostty (Wayland): single alt+o hides and stays hidden; a
  second press reopens.