### PR TITLE
fix: forward abort signal to dialog prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Configurable `auto` or always-single-column layouts for wide single-select prompts. Closes #30.
 - `herdr:blocked` lifecycle events while waiting for structured or freeform user input.
 
+### Fixed
+
+- Forward tool cancellation to freeform input and RPC dialog fallbacks so aborting `ask_user` dismisses every prompt path consistently.
+
 ## [0.13.1](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.1) - 2026-08-01
 
 ### Fixed

--- a/index.test.ts
+++ b/index.test.ts
@@ -344,6 +344,36 @@ describe("ask_user", () => {
       ]);
    });
 
+   test("tool abort cancels freeform input", async () => {
+      const tool = await setupTool();
+      const controller = new AbortController();
+      let capturedOpts: any;
+
+      const execution = tool.execute(
+         "tool-call-id",
+         { question: "Why?", options: [] },
+         controller.signal,
+         undefined,
+         {
+            hasUI: true,
+            ui: {
+               input: async (_title: string, _placeholder: string, opts: any) => {
+                  capturedOpts = opts;
+                  return new Promise((resolve) => {
+                     opts.signal.addEventListener("abort", () => resolve(undefined), { once: true });
+                  });
+               },
+            },
+         },
+      );
+
+      controller.abort();
+      const result = await execution;
+
+      expect(capturedOpts).toEqual({ signal: controller.signal });
+      expect(result.details.cancelled).toBe(true);
+   });
+
    test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;
@@ -2952,8 +2982,9 @@ describe("ask_user", () => {
          expect(selectTitle).toContain("The sky is blue today.");
       });
 
-      test("passes timeout to dialog methods", async () => {
+      test("passes the tool abort signal and timeout to dialog methods", async () => {
          const tool = await setupTool();
+         const controller = new AbortController();
          let capturedOpts: any;
 
          await tool.execute(
@@ -2964,7 +2995,7 @@ describe("ask_user", () => {
                allowFreeform: false,
                timeout: 5000,
             },
-            undefined,
+            controller.signal,
             undefined,
             {
                hasUI: true,
@@ -2979,7 +3010,7 @@ describe("ask_user", () => {
             },
          );
 
-         expect(capturedOpts).toEqual({ timeout: 5000 });
+         expect(capturedOpts).toEqual({ signal: controller.signal, timeout: 5000 });
       });
    });
 });

--- a/index.ts
+++ b/index.ts
@@ -1935,9 +1935,8 @@ async function askViaDialogs(
    allowMultiple: boolean,
    allowFreeform: boolean,
    allowComment: boolean,
-   timeout?: number,
+   dialogOpts?: { signal?: AbortSignal; timeout?: number },
 ): Promise<AskUIResult | null> {
-   const dialogOpts = timeout ? { timeout } : undefined;
    const prompt = context ? `${question}\n\nContext:\n${context}` : question;
 
    if (allowMultiple) {
@@ -2110,6 +2109,9 @@ export default function(pi: ExtensionAPI) {
          };
          const options = rawOptions.map(coerceOption).filter((option): option is QuestionOption => option !== null);
          const normalizedContext = context?.trim() || undefined;
+         const dialogOpts = signal
+            ? (timeout ? { signal, timeout } : { signal })
+            : (timeout ? { timeout } : undefined);
 
          if (rawOptions.length > 0 && options.length === 0) {
             return {
@@ -2149,7 +2151,7 @@ export default function(pi: ExtensionAPI) {
             pi.events.emit("herdr:blocked", { active: true, label: "Waiting for user response" });
             let answer: string | undefined;
             try {
-               answer = await ctx.ui.input(prompt, "Type your answer...", timeout ? { timeout } : undefined);
+               answer = await ctx.ui.input(prompt, "Type your answer...", dialogOpts);
             } finally {
                pi.events.emit("herdr:blocked", { active: false });
             }
@@ -2240,7 +2242,16 @@ export default function(pi: ExtensionAPI) {
                result = customResult;
             } else {
                // RPC/headless mode: degrade to select()/input() dialog protocol
-               result = await askViaDialogs(ctx.ui, question, normalizedContext, options, allowMultiple, allowFreeform, allowComment, timeout);
+               result = await askViaDialogs(
+                  ctx.ui,
+                  question,
+                  normalizedContext,
+                  options,
+                  allowMultiple,
+                  allowFreeform,
+                  allowComment,
+                  dialogOpts,
+               );
             }
          } catch (error) {
             const message =


### PR DESCRIPTION
## Summary

- forward the tool `AbortSignal` to freeform input prompts
- pass the same signal through RPC/dialog fallbacks
- add regression coverage and update the changelog

## Why

The structured custom UI already handles tool cancellation, but freeform input and dialog fallback paths only forwarded `timeout`. Aborting the tool could therefore leave those prompts waiting for user input.

## Verification

- targeted cancellation test through Pi's extension loader for freeform and dialog fallback paths
- `npm run check`
- `git diff --check`

The full Bun test suite was not run locally because Bun is unavailable in this environment.
