### PR TITLE
fix: signal ask_user execution failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Tool execution failures now throw so Pi records them as errors instead of treating returned `isError` fields as successful results.
+
 ### Added
 
 - Responsive context collapse for overlay and inline prompts; oversized context preserves the full value while keeping the question and choices visible, and `ctrl+e` toggles the expanded view.

--- a/index.test.ts
+++ b/index.test.ts
@@ -202,7 +202,7 @@ beforeAll(() => {
 
 type RegisteredTool = {
    execute: (...args: any[]) => Promise<any>;
-   renderResult: (result: any, options: any, theme: any) => any;
+   renderResult: (result: any, options: any, theme: any, context?: any) => any;
 };
 
 function stubEnv(key: string, value: string): void {
@@ -239,6 +239,16 @@ async function setupTool(): Promise<RegisteredTool> {
    }
 
    return registeredTool;
+}
+
+async function rejectedError(promise: Promise<unknown>): Promise<Error> {
+   try {
+      await promise;
+   } catch (error) {
+      if (error instanceof Error) return error;
+      throw new Error(`Expected an Error rejection, received ${String(error)}`);
+   }
+   throw new Error("Expected promise to reject");
 }
 
 function createTheme() {
@@ -308,22 +318,39 @@ describe("ask_user", () => {
       ]);
    });
 
-   test("clears Herdr blocked lifecycle when structured UI rejects", async () => {
+   test("throws and clears Herdr blocked lifecycle when structured UI rejects", async () => {
       const tool = await setupTool();
 
-      const result = await tool.execute(
+      const error = await rejectedError(tool.execute(
          "tool-call-id",
          { question: "Continue?", options: ["Yes"] },
          undefined,
          undefined,
          { hasUI: true, ui: { custom: async () => { throw new Error("UI failed"); } } },
-      );
+      ));
 
-      expect(result.isError).toBe(true);
+      expect(error.message).toBe("UI failed");
       expect(emittedEvents.filter((event) => event.name === "herdr:blocked")).toEqual([
          { name: "herdr:blocked", payload: { active: true, label: "Waiting for user response" } },
          { name: "herdr:blocked", payload: { active: false } },
       ]);
+   });
+
+   test("throws when interactive UI is unavailable", async () => {
+      const tool = await setupTool();
+
+      const error = await rejectedError(tool.execute(
+         "tool-call-id",
+         { question: "Continue?", options: ["Yes", "No"] },
+         undefined,
+         undefined,
+         { hasUI: false },
+      ));
+
+      expect(error.message).toContain("Ask requires interactive mode");
+      expect(error.message).toContain("Continue?");
+      expect(error.message).toContain("1. Yes");
+      expect(error.message).toContain("2. No");
    });
 
    test("clears Herdr blocked lifecycle when freeform input is cancelled", async () => {
@@ -945,6 +972,21 @@ describe("ask_user", () => {
 
       expect(rendered).toContain("Waiting for user input...");
       expect(rendered).not.toContain("✓");
+   });
+
+   test("renders thrown tool failures as errors", async () => {
+      const tool = await setupTool();
+      const component = tool.renderResult(
+         { content: [{ type: "text", text: "UI failed" }], details: undefined },
+         { expanded: false, isPartial: false },
+         createTheme(),
+         { isError: true },
+      ) as any;
+
+      const rendered = component.render(120).join("\n");
+
+      expect(rendered).toContain("✗ UI failed");
+      expect(rendered).not.toContain("Cancelled");
    });
 
    test("marks each selected option in expanded multi-select results", async () => {
@@ -2668,11 +2710,11 @@ describe("ask_user", () => {
          ]);
       });
 
-      test("returns an error instead of opening UI when every supplied option is malformed", async () => {
+      test("throws instead of opening UI when every supplied option is malformed", async () => {
          const tool = await setupTool();
          let calls = 0;
 
-         const result = await tool.execute(
+         const error = await rejectedError(tool.execute(
             "tool-call-id",
             {
                question: "Pick one",
@@ -2697,13 +2739,10 @@ describe("ask_user", () => {
                   },
                },
             },
-         );
+         ));
 
-         const text = result.content.map((part: { text?: string }) => part.text ?? "").join("\n");
-         expect(result.isError).toBe(true);
-         expect(text).toContain("option(s) were malformed");
-         expect(text).toContain("{ \"title\": \"Short label\", \"description\": \"Optional detail\" }");
-         expect(result.details.error).toBe("Malformed options: no entry had a usable title");
+         expect(error.message).toContain("option(s) were malformed");
+         expect(error.message).toContain("{ \"title\": \"Short label\", \"description\": \"Optional detail\" }");
          expect(calls).toBe(0);
       });
 

--- a/index.ts
+++ b/index.ts
@@ -2112,19 +2112,11 @@ export default function(pi: ExtensionAPI) {
          const normalizedContext = context?.trim() || undefined;
 
          if (rawOptions.length > 0 && options.length === 0) {
-            return {
-               content: [
-                  {
-                     type: "text",
-                     text:
-                        `All ${rawOptions.length} option(s) were malformed, so nothing could be shown to the user. `
-                        + `Each option must be a plain string or an object like { "title": "Short label", "description": "Optional detail" }. `
-                        + `Call ask_user again with corrected options.`,
-                  },
-               ],
-               isError: true,
-               details: { error: "Malformed options: no entry had a usable title" },
-            };
+            throw new Error(
+               `All ${rawOptions.length} option(s) were malformed, so nothing could be shown to the user. `
+               + `Each option must be a plain string or an object like { "title": "Short label", "description": "Optional detail" }. `
+               + `Call ask_user again with corrected options.`,
+            );
          }
 
          if (!ctx.hasUI || !ctx.ui) {
@@ -2132,16 +2124,9 @@ export default function(pi: ExtensionAPI) {
             const freeformHint = allowFreeform ? "\n\nYou can also answer freely." : "";
             const commentHint = allowComment ? "\n\nAfter choosing an option, you may add an optional comment." : "";
             const contextText = normalizedContext ? `\n\nContext:\n${normalizedContext}` : "";
-            return {
-               content: [
-                  {
-                     type: "text",
-                     text: `Ask requires interactive mode. Please answer:\n\n${question}${contextText}${optionText}${freeformHint}${commentHint}`,
-                  },
-               ],
-               isError: true,
-               details: { question, context: normalizedContext, options, response: null, cancelled: true } as AskToolDetails,
-            };
+            throw new Error(
+               `Ask requires interactive mode. Please answer:\n\n${question}${contextText}${optionText}${freeformHint}${commentHint}`,
+            );
          }
 
          if (options.length === 0) {
@@ -2243,13 +2228,7 @@ export default function(pi: ExtensionAPI) {
                result = await askViaDialogs(ctx.ui, question, normalizedContext, options, allowMultiple, allowFreeform, allowComment, timeout);
             }
          } catch (error) {
-            const message =
-               error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error);
-            return {
-               content: [{ type: "text", text: `Ask tool failed: ${message}` }],
-               isError: true,
-               details: { error: message },
-            };
+            throw error instanceof Error ? error : new Error(String(error));
          } finally {
             removeOverlayInputListener?.();
             pi.events.emit("herdr:blocked", { active: false });
@@ -2298,11 +2277,17 @@ export default function(pi: ExtensionAPI) {
          return new Text(text, 0, 0);
       },
 
-      renderResult(result, options, theme) {
+      renderResult(result, options, theme, context) {
          const details = result.details as (AskToolDetails & { error?: string }) | undefined;
 
-         if (details?.error) {
-            return new Text(theme.fg("error", `✗ ${details.error}`), 0, 0);
+         if (details?.error || context?.isError) {
+            const message = details?.error ?? (
+               result.content
+                  ?.map((part) => part.type === "text" ? part.text : "")
+                  .join("\n")
+                  .trim() || "ask_user failed"
+            );
+            return new Text(theme.fg("error", `✗ ${message}`), 0, 0);
          }
 
          if (options.isPartial) {


### PR DESCRIPTION
## Summary

- throw for malformed options, unavailable UI, and UI execution failures
- render thrown tool failures using Pi's renderer error context
- update regression tests and the changelog

## Why

Pi only marks a custom tool execution as failed when `execute()` throws. Returning an object with `isError: true` does not set the tool result error flag, so these three `ask_user` failure paths were emitted as successful executions.

See Pi's [custom tool error contract](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md#tool-definition).

## Verification

- `tsc --noEmit --strict --skipLibCheck --module esnext --moduleResolution bundler --target es2022 index.ts`
- test sources type-check with Bun types
- targeted runtime smoke checks for all three rejection paths, lifecycle cleanup, and error rendering
- `npm pack --dry-run`

The full Bun test suite was not run locally because Bun is unavailable in this environment.
