### PR TITLE
fix: register ask_user on hosts whose TypeBox shim rejects Optional(Unsafe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - The overlay visibility shortcut now ignores Kitty keyboard repeat and release events, preventing one `alt+o` keypress from hiding and immediately reopening the prompt.
+- `ask_user` failing to register on oh-my-pi 17.2.x, whose TypeBox shim returned a plain object from `Type.Unsafe` that `Type.Optional` could not wrap (`asRuntime(schema).or is not a function`). `StringEnum` now probes the host builder and falls back to a literal union — which those hosts already collapse to the flat `{ type: "string", enum }` form — while real TypeBox keeps the flat enum Google's function-calling API requires. Closes #38.
 
 ## [0.13.1](https://github.com/edlsh/pi-ask-user/releases/tag/v0.13.1) - 2026-08-01
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, mock, onTestFinished, test } from "bun:test";
+import type { StringEnumBuilder } from "./index";
 
 let editorInputs: string[] = [];
 let editorText = "";
@@ -2730,6 +2731,65 @@ describe("ask_user", () => {
          expect(optionSchema).not.toContain("Type.Union");
          expect(optionSchema).not.toContain("anyOf");
          expect(optionSchema).not.toContain("oneOf");
+      });
+   });
+
+   describe("issue #38 typebox shim compatibility", () => {
+      // Fakes stand in for the real builders; their signatures are narrower than
+      // TypeBox's generics, so the cast is the only way to hand them to StringEnum.
+      const realTypeBoxLike = {
+         Unsafe: (schema: Record<string, unknown>) => ({ ...schema }),
+         Optional: (schema: unknown) => schema,
+         Union: () => {
+            throw new Error("union path must not run on real TypeBox");
+         },
+         Literal: (value: unknown) => value,
+      } as unknown as StringEnumBuilder;
+
+      type RuntimeSchema = {
+         runtime: true;
+         members: unknown[];
+         meta: Record<string, unknown>;
+         or: () => RuntimeSchema;
+         describe: (text: string) => RuntimeSchema;
+         default: (value: unknown) => RuntimeSchema;
+      };
+      const runtimeSchema = (members: unknown[], meta: Record<string, unknown> = {}): RuntimeSchema => ({
+         runtime: true,
+         members,
+         meta,
+         or: () => runtimeSchema(members, meta),
+         describe: (text) => runtimeSchema(members, { ...meta, description: text }),
+         default: (value) => runtimeSchema(members, { ...meta, default: value }),
+      });
+      const isRuntimeSchema = (value: unknown): value is RuntimeSchema =>
+         typeof value === "object" && value !== null && "or" in value && typeof value.or === "function";
+      // Mirrors oh-my-pi's legacy-typebox shim: Unsafe yields a plain object,
+      // Optional evaluates `asRuntime(schema).or(...)`, Union ignores options.
+      const ompOptional = (schema: unknown) => {
+         if (!isRuntimeSchema(schema)) throw new TypeError("asRuntime(schema).or is not a function");
+         return schema.or();
+      };
+      const ompLike = {
+         Unsafe: (schema: Record<string, unknown>) => ({ ...schema }),
+         Optional: ompOptional,
+         Union: (members: unknown[]) => runtimeSchema(members),
+         Literal: (value: unknown) => ({ literal: value }),
+      } as unknown as StringEnumBuilder;
+
+      test("emits the flat enum on hosts whose Type.Optional accepts Type.Unsafe", async () => {
+         const { StringEnum } = await import("./index");
+         const schema: unknown = StringEnum(["overlay", "inline"] as const, { description: "mode", default: "overlay" }, realTypeBoxLike);
+         expect(schema).toEqual({ type: "string", enum: ["overlay", "inline"], description: "mode", default: "overlay" });
+      });
+
+      test("falls back to a literal union that Type.Optional can wrap on omp-style shims", async () => {
+         const { StringEnum } = await import("./index");
+         const schema: unknown = StringEnum(["overlay", "inline"] as const, { description: "mode" }, ompLike);
+         if (!isRuntimeSchema(schema)) throw new Error("expected a runtime union schema");
+         expect(schema.members).toEqual([{ literal: "overlay" }, { literal: "inline" }]);
+         expect(schema.meta).toEqual({ description: "mode" });
+         expect(() => ompOptional(schema)).not.toThrow();
       });
    });
 

--- a/index.ts
+++ b/index.ts
@@ -43,17 +43,45 @@ const ASK_USER_VERSION: string = (_require("./package.json") as { version: strin
  * `anyOf`/`oneOf` shape that `Type.Union([Type.Literal()])` produces. Google's
  * function-calling API rejects the union form. Local copy of pi-ai's StringEnum
  * to avoid a peer dependency for one helper.
+ *
+ * Some hosts (oh-my-pi) alias `@sinclair/typebox` to a shim whose `Type.Unsafe`
+ * returns a plain object that `Type.Optional` cannot wrap (issue #38). On those
+ * hosts a union of literals is a real runtime schema *and* already collapses to
+ * the flat enum form, so we probe the builder and pick whichever path it
+ * supports. `builder` is injectable for tests only.
  */
-function StringEnum<const T extends readonly string[]>(
+export type StringEnumBuilder = Pick<typeof Type, "Unsafe" | "Optional" | "Union" | "Literal">;
+
+export function StringEnum<const T extends readonly string[]>(
    values: T,
    options?: { description?: string; default?: T[number] },
+   builder: StringEnumBuilder = Type,
 ): TUnsafe<T[number]> {
-   return Type.Unsafe<T[number]>({
-      type: "string",
-      enum: [...values],
+   const meta = {
       ...(options?.description ? { description: options.description } : {}),
       ...(options?.default !== undefined ? { default: options.default } : {}),
-   });
+   };
+   try {
+      builder.Optional(builder.Unsafe<string>({ type: "string" }));
+      return builder.Unsafe<T[number]>({ type: "string", enum: [...values], ...meta });
+   } catch {
+      // fall through to the union path below
+   }
+   // Shim path: the union is a runtime schema, so `Type.Optional` works and the
+   // enclosing `Type.Object` keeps every optional key optional. Chainable
+   // `.describe()`/`.default()` are the shim's way to attach metadata; the
+   // options argument covers builders that take it positionally instead.
+   let schema = builder.Union(values.map((value) => builder.Literal(value)), meta) as unknown as {
+      describe?: (text: string) => unknown;
+      default?: (value: unknown) => unknown;
+   };
+   if (options?.description && typeof schema.describe === "function") {
+      schema = schema.describe(options.description) as typeof schema;
+   }
+   if (options?.default !== undefined && typeof schema.default === "function") {
+      schema = schema.default(options.default) as typeof schema;
+   }
+   return schema as unknown as TUnsafe<T[number]>;
 }
 
 /**


### PR DESCRIPTION
Closes #38.

oh-my-pi 17.2.x aliases `@sinclair/typebox` to a shim where `Type.Unsafe` returns a plain object and `Type.Optional` throws `asRuntime(schema).or is not a function`, so `ask_user` never registered while the bundled skill still loaded.

- `StringEnum` now probes `Type.Optional(Type.Unsafe(...))` on the host builder and falls back to `Type.Union` of literals when it throws. Those hosts already collapse the union to `{ type: "string", enum }`, and the union is a runtime schema so the enclosing `Type.Object` keeps optional keys optional.
- Real TypeBox keeps the flat `Unsafe` enum that Google function calling requires; behaviour there is byte-identical.
- `builder` is injectable for tests only; two regression tests cover both paths with fakes modelled on the shim.

Note: omp fixed the shim upstream on 2026-08-10/13 (>=17.3), so this only matters for hosts pinned to 17.2.x. Verified locally against omp 18.1.3 that the probe takes the `Unsafe` path.