### PR TITLE
fix: redact ask:answered / ask:cancelled payloads by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Configurable `auto` or always-single-column layouts for wide single-select prompts. Closes #30.
 - `herdr:blocked` lifecycle events while waiting for structured or freeform user input.
 
+### Changed
+
+- `ask:answered` and `ask:cancelled` events are redacted by default: they now carry only the question and the response `kind`, since every installed extension receives them. Set `PI_ASK_USER_EMIT_FULL_EVENTS=true` to restore the previous payloads with `context`, `options`, and the full `response`. The tool result's `details` is unchanged. Closes #51.
+
 ### Fixed
 
 - The overlay visibility shortcut now ignores Kitty keyboard repeat and release events, preventing one `alt+o` keypress from hiding and immediately reopening the prompt.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ export PI_ASK_USER_SINGLE_SELECT_LAYOUT=list
 export PI_ASK_USER_ALLOW_COMMENT=true
 export PI_ASK_USER_OVERLAY_TOGGLE_KEY=alt+h
 export PI_ASK_USER_COMMENT_TOGGLE_KEY=alt+c
+export PI_ASK_USER_EMIT_FULL_EVENTS=true
 ```
 
 Environment variables must be present in the process that launches Pi. If Pi is launched from a desktop app or a different shell, changes in `~/.zshrc` may not be inherited; launch Pi from a terminal where `echo $PI_ASK_USER_DISPLAY_MODE` shows the expected value.
@@ -163,9 +164,20 @@ If you prefer never to see the overlay, set `displayMode: "inline"` per call or 
 
 If context wraps beyond the available decision area, `ask_user` collapses it into a one-line summary so the question and at least one choice remain visible. Press the context key shown in the prompt (`ctrl+e` by default) to expand or collapse the complete context; expanded context remains bounded and scrollable with the existing prompt-scroll keys in both display modes.
 
-### Waiting lifecycle event
+### Events
 
 While an interactive prompt is open, the extension emits `herdr:blocked` with `{ active: true, label: "Waiting for user response" }`. It emits `{ active: false }` in `finally`, including cancellation and error paths. Hosts without a listener are unaffected.
+
+When the prompt resolves it emits `ask:answered` or `ask:cancelled`. Every installed extension receives these, so by default they carry only what is needed to correlate the prompt with its outcome:
+
+```typescript
+// ask:answered
+{ question: string; response: { kind: "selection" | "freeform" } }
+// ask:cancelled
+{ question: string }
+```
+
+Set `PI_ASK_USER_EMIT_FULL_EVENTS=true` (or `1`, `yes`, `on`) to restore the full payloads — `context`, the offered `options` on cancel, and the complete `response` including selections, comment, and freeform text. Leave it unset unless another extension you trust needs the answer itself; the full response is always available to the agent through the tool result's `details`.
 
 ## Known limitations
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -348,6 +348,67 @@ describe("ask_user", () => {
       ]);
    });
 
+   describe("issue #51 event payload redaction", () => {
+      const answerFreeform = (tool: RegisteredTool) =>
+         tool.execute(
+            "tool-call-id",
+            { question: "Why?", context: "secret context", options: [] },
+            undefined,
+            undefined,
+            { hasUI: true, ui: { input: async () => "my private answer" } },
+         );
+      const cancelStructured = (tool: RegisteredTool) =>
+         tool.execute(
+            "tool-call-id",
+            { question: "Pick", context: "secret context", options: ["A", "B"] },
+            undefined,
+            undefined,
+            { hasUI: true, ui: { custom: async () => null } },
+         );
+
+      test("ask:answered carries only the question and response kind by default", async () => {
+         const tool = await setupTool();
+         const result = await answerFreeform(tool);
+
+         expect(result.details.response).toEqual({ kind: "freeform", text: "my private answer" });
+         expect(emittedEvents.filter((event) => event.name === "ask:answered")).toEqual([
+            { name: "ask:answered", payload: { question: "Why?", response: { kind: "freeform" } } },
+         ]);
+      });
+
+      test("ask:cancelled carries only the question by default", async () => {
+         const tool = await setupTool();
+         const result = await cancelStructured(tool);
+
+         expect(result.details.cancelled).toBe(true);
+         expect(emittedEvents.filter((event) => event.name === "ask:cancelled")).toEqual([
+            { name: "ask:cancelled", payload: { question: "Pick" } },
+         ]);
+      });
+
+      test("PI_ASK_USER_EMIT_FULL_EVENTS=true restores the full payloads", async () => {
+         stubEnv("PI_ASK_USER_EMIT_FULL_EVENTS", "true");
+         const tool = await setupTool();
+         await answerFreeform(tool);
+         await cancelStructured(tool);
+
+         expect(emittedEvents.filter((event) => event.name.startsWith("ask:"))).toEqual([
+            {
+               name: "ask:answered",
+               payload: { question: "Why?", context: "secret context", response: { kind: "freeform", text: "my private answer" } },
+            },
+            {
+               name: "ask:cancelled",
+               payload: {
+                  question: "Pick",
+                  context: "secret context",
+                  options: [{ title: "A" }, { title: "B" }],
+               },
+            },
+         ]);
+      });
+   });
+
    test("uses overlay mode by default", async () => {
       const tool = await setupTool();
       let capturedOptions: any;
@@ -1510,7 +1571,7 @@ describe("ask_user", () => {
       expect(result.isError).not.toBe(true);
       expect(result.details.response).toEqual({ kind: "freeform", text: "custom from editor" });
       expect(result.details.cancelled).toBe(false);
-      expect(answeredEvent?.payload.response).toEqual({ kind: "freeform", text: "custom from editor" });
+      expect(answeredEvent?.payload).toEqual({ question: "Which option should we use?", response: { kind: "freeform" } });
       expect(editorInputs).toEqual(["enter"]);
    });
 

--- a/index.ts
+++ b/index.ts
@@ -2140,6 +2140,22 @@ export default function(pi: ExtensionAPI) {
          };
          const options = rawOptions.map(coerceOption).filter((option): option is QuestionOption => option !== null);
          const normalizedContext = context?.trim() || undefined;
+         // Every installed extension receives these events. By default only the
+         // question and the response kind are broadcast; the context and the
+         // user's actual selections/comment/freeform text stay inside the tool
+         // result unless the user opts in (#51).
+         const emitFullEvents = parseBooleanPreference(process.env.PI_ASK_USER_EMIT_FULL_EVENTS) ?? false;
+         const emitAnswered = (response: AskResponse): void => {
+            pi.events.emit(
+               "ask:answered",
+               emitFullEvents
+                  ? { question, context: normalizedContext, response }
+                  : { question, response: { kind: response.kind } },
+            );
+         };
+         const emitCancelled = (): void => {
+            pi.events.emit("ask:cancelled", emitFullEvents ? { question, context: normalizedContext, options } : { question });
+         };
 
          if (rawOptions.length > 0 && options.length === 0) {
             return {
@@ -2192,7 +2208,7 @@ export default function(pi: ExtensionAPI) {
                };
             }
 
-            pi.events.emit("ask:answered", { question, context: normalizedContext, response });
+            emitAnswered(response);
             return {
                content: [{ type: "text", text: `User answered: ${formatResponseSummary(response)}` }],
                details: { question, context: normalizedContext, options, response, cancelled: false } as AskToolDetails,
@@ -2292,18 +2308,14 @@ export default function(pi: ExtensionAPI) {
          }
 
          if (result === null) {
-            pi.events.emit("ask:cancelled", { question, context: normalizedContext, options });
+            emitCancelled();
             return {
                content: [{ type: "text", text: "User cancelled the question" }],
                details: { question, context: normalizedContext, options, response: null, cancelled: true } as AskToolDetails,
             };
          }
 
-         pi.events.emit("ask:answered", {
-            question,
-            context: normalizedContext,
-            response: result,
-         });
+         emitAnswered(result);
          return {
             content: [{ type: "text", text: `User answered: ${formatResponseSummary(result)}` }],
             details: {


### PR DESCRIPTION
Closes #51. Stacked on #55.

Every installed extension receives `ask:answered` / `ask:cancelled`, so the full context and the user's selections, comment, or freeform text crossed a boundary users reasonably assume is limited to the agent session.

- Default payloads are now `{ question, response: { kind } }` and `{ question }`.
- `PI_ASK_USER_EMIT_FULL_EVENTS=true` restores the previous payloads (`context`, `options`, full `response`).
- Tool result `details` are unchanged, so the agent still sees the full answer.
- README documents both shapes; CHANGELOG lists this under **Changed** since it is a contract change for any event consumer.