### PR TITLE
feat: contextExpanded parameter and PI_ASK_USER_CONTEXT_EXPANDED preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Responsive context collapse for overlay and inline prompts; oversized context preserves the full value while keeping the question and choices visible, and `ctrl+e` toggles the expanded view.
 - Configurable `auto` or always-single-column layouts for wide single-select prompts. Closes #30.
 - `herdr:blocked` lifecycle events while waiting for structured or freeform user input.
+- `contextExpanded` parameter and `PI_ASK_USER_CONTEXT_EXPANDED` preference for opening oversized context expanded by default; per-call value wins, `ctrl+e` still toggles. Closes #45.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ export PI_ASK_USER_ALLOW_COMMENT=true
 export PI_ASK_USER_OVERLAY_TOGGLE_KEY=alt+h
 export PI_ASK_USER_COMMENT_TOGGLE_KEY=alt+c
 export PI_ASK_USER_EMIT_FULL_EVENTS=true
+export PI_ASK_USER_CONTEXT_EXPANDED=true
 ```
 
 Environment variables must be present in the process that launches Pi. If Pi is launched from a desktop app or a different shell, changes in `~/.zshrc` may not be inherited; launch Pi from a terminal where `echo $PI_ASK_USER_DISPLAY_MODE` shows the expected value.
@@ -134,6 +135,16 @@ Effective order:
 1. Per-call `allowComment` parameter (if provided)
 2. `PI_ASK_USER_ALLOW_COMMENT` (`true`, `1`, `yes`, or `on`; corresponding false values are also accepted)
 3. Fallback default: `false`
+
+### Context expansion
+
+Oversized context collapses behind a one-line summary so the question and choices stay visible. To start expanded instead:
+
+1. Per-call `contextExpanded` parameter (if provided)
+2. `PI_ASK_USER_CONTEXT_EXPANDED` (`true`, `1`, `yes`, or `on`; corresponding false values are also accepted)
+3. Fallback default: `false`
+
+`ctrl+e` still toggles from whichever state the prompt opened in.
 
 ### Shortcuts
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1882,6 +1882,63 @@ describe("ask_user", () => {
       expect(result.details.context).toContain("Context detail.");
    });
 
+   describe("issue #45 contextExpanded preference", () => {
+      const renderFirstFrame = async (tool: RegisteredTool, params: Record<string, unknown>) => {
+         let firstFrame = "";
+         await tool.execute(
+            "tool-call-id",
+            {
+               question: "Which option should we use?",
+               context: "Context detail. ".repeat(80),
+               options: ["Alpha", "Beta"],
+               ...params,
+            },
+            undefined,
+            undefined,
+            {
+               hasUI: true,
+               ui: {
+                  custom: async (factory: any) => {
+                     const component = factory(
+                        { requestRender() { }, terminal: { rows: 40 } },
+                        createTheme(),
+                        createKeybindings(),
+                        () => { },
+                     );
+                     firstFrame = component.render(50).join("\n");
+                     return null;
+                  },
+               },
+            },
+         );
+         return firstFrame;
+      };
+
+      test("per-call contextExpanded: true opens oversized context expanded", async () => {
+         const tool = await setupTool();
+         const frame = await renderFirstFrame(tool, { contextExpanded: true });
+         expect(frame).toContain("Context detail.");
+         expect(frame).not.toContain("Context (");
+         expect(frame).toContain("ctrl+e collapse context");
+      });
+
+      test("uses PI_ASK_USER_CONTEXT_EXPANDED when the call omits contextExpanded", async () => {
+         stubEnv("PI_ASK_USER_CONTEXT_EXPANDED", "true");
+         const tool = await setupTool();
+         const frame = await renderFirstFrame(tool, {});
+         expect(frame).toContain("Context detail.");
+         expect(frame).not.toContain("Context (");
+      });
+
+      test("per-call contextExpanded: false overrides PI_ASK_USER_CONTEXT_EXPANDED", async () => {
+         stubEnv("PI_ASK_USER_CONTEXT_EXPANDED", "true");
+         const tool = await setupTool();
+         const frame = await renderFirstFrame(tool, { contextExpanded: false });
+         expect(frame).toContain("Context (");
+         expect(frame).not.toContain("Context detail.");
+      });
+   });
+
    test("scrolls constrained multi-select overlays to the comment and freeform rows", async () => {
       const tool = await setupTool();
       let initialRendered: string[] = [];

--- a/index.ts
+++ b/index.ts
@@ -128,6 +128,7 @@ interface AskParams {
    allowComment?: boolean;
    displayMode?: AskDisplayMode;
    singleSelectLayout?: AskSingleSelectLayout;
+   contextExpanded?: boolean;
    overlayToggleKey?: string | null;
    commentToggleKey?: string | null;
    timeout?: number;
@@ -1120,6 +1121,7 @@ class AskComponent extends Container {
    private allowComment: boolean;
    private displayMode: AskDisplayMode;
    private singleSelectLayout: AskSingleSelectLayout;
+   private preferExpandedContext: boolean;
    private tui: TUI;
    private theme: Theme;
    private keybindings: KeybindingsManager;
@@ -1169,6 +1171,7 @@ class AskComponent extends Container {
       allowComment: boolean,
       displayMode: AskDisplayMode,
       singleSelectLayout: AskSingleSelectLayout,
+      contextExpanded: boolean,
       tui: TUI,
       theme: Theme,
       keybindings: KeybindingsManager,
@@ -1185,6 +1188,7 @@ class AskComponent extends Container {
       this.allowComment = allowComment;
       this.displayMode = displayMode;
       this.singleSelectLayout = singleSelectLayout;
+      this.preferExpandedContext = contextExpanded;
       this.tui = tui;
       this.theme = theme;
       this.keybindings = keybindings;
@@ -1370,7 +1374,10 @@ class AskComponent extends Container {
    private setContextIsCollapsible(value: boolean): void {
       if (this.contextIsCollapsible === value) return;
       this.contextIsCollapsible = value;
-      if (!value) this.contextExpanded = false;
+      // Whenever context becomes collapsible (first render, or a resize that
+      // shrinks the viewport) start in the user's preferred state; ctrl+e still
+      // toggles from there.
+      this.contextExpanded = value && this.preferExpandedContext;
       this.updateHelpText();
    }
 
@@ -2078,6 +2085,11 @@ export default function(pi: ExtensionAPI) {
                description: "Single-select layout. 'auto' uses a details pane on wide terminals; 'list' always keeps descriptions below options. Default: PI_ASK_USER_SINGLE_SELECT_LAYOUT if set, otherwise 'auto'.",
             }),
          ),
+         contextExpanded: Type.Optional(
+            Type.Boolean({
+               description: "Start with oversized context expanded instead of collapsed behind a one-line summary. Default: PI_ASK_USER_CONTEXT_EXPANDED env var if set, otherwise false.",
+            }),
+         ),
          overlayToggleKey: Type.Optional(
             Type.String({
                description:
@@ -2112,6 +2124,7 @@ export default function(pi: ExtensionAPI) {
             allowComment: requestedAllowComment,
             displayMode,
             singleSelectLayout,
+            contextExpanded: requestedContextExpanded,
             overlayToggleKey,
             commentToggleKey,
             timeout,
@@ -2125,6 +2138,9 @@ export default function(pi: ExtensionAPI) {
             ?? (envSingleSelectLayout === "list" ? "list" : "auto");
          const allowComment = requestedAllowComment
             ?? parseBooleanPreference(process.env.PI_ASK_USER_ALLOW_COMMENT)
+            ?? false;
+         const contextExpanded = requestedContextExpanded
+            ?? parseBooleanPreference(process.env.PI_ASK_USER_CONTEXT_EXPANDED)
             ?? false;
          const shortcuts: ResolvedAskShortcuts = {
             overlayToggle: resolveShortcut(
@@ -2245,6 +2261,7 @@ export default function(pi: ExtensionAPI) {
                   allowComment,
                   effectiveDisplayMode,
                   effectiveSingleSelectLayout,
+                  contextExpanded,
                   tui,
                   theme,
                   keybindings,

--- a/skills/ask-user/SKILL.md
+++ b/skills/ask-user/SKILL.md
@@ -55,6 +55,7 @@ Call `ask_user` with one decision at a time:
 - `allowMultiple`: `false` unless independent selections are genuinely needed
 - `allowFreeform`: usually `true`
 - `displayMode` *(optional)*: `"overlay"` (default) or `"inline"`. Use `"inline"` when preceding assistant context (summary, trade-offs, recommendation) is essential to the decision and should remain visible — overlays cover the conversation underneath. The user may set a personal default via the `PI_ASK_USER_DISPLAY_MODE` environment variable; only pass this when you intentionally want to override it for one call.
+- `contextExpanded` *(optional)*: `true` opens oversized context fully expanded instead of collapsed behind a one-line summary. The user may set a personal default via `PI_ASK_USER_CONTEXT_EXPANDED`; only pass this when the context is the evidence the user needs to weigh the options.
 ### 5) Commit the decision
 After response:
 - restate the decision in plain language


### PR DESCRIPTION
Closes #45. Stacked on #56.

Oversized context still collapses behind a one-line summary by default. Evidence-heavy prompts can now open expanded without pressing `ctrl+e` on every question.

- Per-call `contextExpanded?: boolean`, env `PI_ASK_USER_CONTEXT_EXPANDED`, same resolution order as the other preferences (call > env > `false`).
- The preference is re-applied whenever context becomes collapsible (first render or a shrinking resize), so `ctrl+e` still toggles from the chosen starting state.
- README, skill, and CHANGELOG updated; three tests cover per-call, env, and per-call-overrides-env.